### PR TITLE
Fix GUI build - Awesomium browser only supports x86 builds

### DIFF
--- a/PoGo.NecroBot.GUI/PoGo.NecroBot.GUI.csproj
+++ b/PoGo.NecroBot.GUI/PoGo.NecroBot.GUI.csproj
@@ -47,7 +47,7 @@
     <OutputPath>..\PoGo.NecroBot.CLI\bin\Debug\GUI\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
@@ -57,7 +57,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>


### PR DESCRIPTION
## Short Description:
Targeting ```AnyCPU``` causes GUI project to not build at all since Awesomium browser is x86 only.  ```PlatformTarget``` needs to be set to ```x86```.