### PR TITLE
check Timestamps & delete older then 24h 

### DIFF
--- a/PoGo.NecroBot.Logic/State/LoadSaveState.cs
+++ b/PoGo.NecroBot.Logic/State/LoadSaveState.cs
@@ -86,6 +86,9 @@ namespace PoGo.NecroBot.Logic.State
                 }
             }
 
+            //Ticks -24h
+            var TSminus24h = DateTime.Now.AddHours(-24).Ticks;
+            
             List<Int64> list = new List<Int64>();
             // for pokestops
             try
@@ -98,7 +101,11 @@ namespace PoGo.NecroBot.Logic.State
                     {
                         if (c.Length > 0)
                         {
-                            list.Add(Convert.ToInt64(c));
+                            //add only values > Ticks-24h
+                            if (Convert.ToInt64(c) > TSminus24h)
+                            {
+                                list.Add(Convert.ToInt64(c));
+                            }
                         }
                     }
                 }
@@ -127,7 +134,11 @@ namespace PoGo.NecroBot.Logic.State
                     {
                         if (c.Length > 0)
                         {
-                            list.Add(Convert.ToInt64(c));
+                            //add only values > Ticks-24h
+                            if (Convert.ToInt64(c) > TSminus24h)
+                            {
+                                list.Add(Convert.ToInt64(c));
+                            }
                         }
                     }
                 }

--- a/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
@@ -47,6 +47,20 @@ namespace PoGo.NecroBot.Logic.Tasks
             if (!session.LogicSettings.UsePokeStopLimit) return false;
             if (session.Stats.PokeStopTimestamps.Count >= session.LogicSettings.PokeStopLimit)
             {
+                //check Timestamps & delete older then 24h
+                var TSminus24h = DateTime.Now.AddHours(-24).Ticks;
+                for (int i = 0; i < session.Stats.PokeStopTimestamps.Count; i++)
+                {
+                    if (session.Stats.PokeStopTimestamps[i] > TSminus24h)
+                    {
+                        session.Stats.PokeStopTimestamps.Remove(session.Stats.PokeStopTimestamps[i]);
+                    }
+                    else
+                    {
+                        i = session.Stats.PokeStopTimestamps.Count;
+                    }
+                }
+
                 // delete uesless data
                 int toRemove = session.Stats.PokeStopTimestamps.Count - session.LogicSettings.PokeStopLimit;
                 if (toRemove > 0)
@@ -61,9 +75,15 @@ namespace PoGo.NecroBot.Logic.Tasks
                     session.EventDispatcher.Send(new ErrorEvent { Message = session.Translation.GetTranslation(TranslationString.PokeStopExceeds, Math.Round(limit - sec)) });
                     return true;
                 }
+                else
+                {
+                    return false;
+                }
             }
-            
-            return false;
+            else
+            {
+                return false;
+            }
         }
 
         public static async Task Execute(ISession session, CancellationToken cancellationToken)


### PR DESCRIPTION
## Short Description:
check Timestamps & delete older then 24h
## Fixes (provide links to github issues if you can):
Bot keeps catching after 998 pokemons #37
 - Possible fix for Farm Pokemons&PokeStops more than limit