### PR TITLE
Entertaining Issue #41 (Request) Mass evolving settings (Pidgey Hoard…

### DIFF
--- a/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
@@ -133,6 +133,7 @@ namespace PoGo.NecroBot.Logic.Interfaces.Configuration
         bool VerboseRecycling { get; }
         double RecycleInventoryAtUsagePercentage { get; }
         double EvolveKeptPokemonsAtStorageUsagePercentage { get; }
+        int OrWhicheverFirst_EvolveKeptPokemonsAtThisNumber { get; }
         bool UseSnipeLimit { get; }
         bool UsePokeStopLimit { get; }
         bool UseCatchLimit { get; }

--- a/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
@@ -133,7 +133,7 @@ namespace PoGo.NecroBot.Logic.Interfaces.Configuration
         bool VerboseRecycling { get; }
         double RecycleInventoryAtUsagePercentage { get; }
         double EvolveKeptPokemonsAtStorageUsagePercentage { get; }
-        int OrWhicheverFirst_EvolveKeptPokemonsAtThisNumber { get; }
+        int EvolveKeptPokemonsOverrideStartIfThisManyReady { get; }
         bool UseSnipeLimit { get; }
         bool UsePokeStopLimit { get; }
         bool UseCatchLimit { get; }

--- a/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
@@ -121,7 +121,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public bool VerboseRecycling => _settings.RecycleConfig.VerboseRecycling;
         public double RecycleInventoryAtUsagePercentage => _settings.RecycleConfig.RecycleInventoryAtUsagePercentage;
         public double EvolveKeptPokemonsAtStorageUsagePercentage => _settings.PokemonConfig.EvolveKeptPokemonsAtStorageUsagePercentage;
-        public int OrWhicheverFirst_EvolveKeptPokemonsAtThisNumber => _settings.PokemonConfig.OrWhicheverFirst_EvolveKeptPokemonsAtThisNumber;
+        public int EvolveKeptPokemonsOverrideStartIfThisManyReady => _settings.PokemonConfig.EvolveKeptPokemonsOverrideStartIfThisManyReady;
         public ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter => _settings.ItemRecycleFilter.Select(itemRecycleFilter => new KeyValuePair<ItemId, int>(itemRecycleFilter.Key, itemRecycleFilter.Value)).ToList();
         public ICollection<PokemonId> PokemonsToEvolve => _settings.PokemonsToEvolve;
         public ICollection<PokemonId> PokemonsToLevelUp => _settings.PokemonsToLevelUp;

--- a/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
@@ -121,6 +121,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public bool VerboseRecycling => _settings.RecycleConfig.VerboseRecycling;
         public double RecycleInventoryAtUsagePercentage => _settings.RecycleConfig.RecycleInventoryAtUsagePercentage;
         public double EvolveKeptPokemonsAtStorageUsagePercentage => _settings.PokemonConfig.EvolveKeptPokemonsAtStorageUsagePercentage;
+        public int OrWhicheverFirst_EvolveKeptPokemonsAtThisNumber => _settings.PokemonConfig.OrWhicheverFirst_EvolveKeptPokemonsAtThisNumber;
         public ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter => _settings.ItemRecycleFilter.Select(itemRecycleFilter => new KeyValuePair<ItemId, int>(itemRecycleFilter.Key, itemRecycleFilter.Value)).ToList();
         public ICollection<PokemonId> PokemonsToEvolve => _settings.PokemonsToEvolve;
         public ICollection<PokemonId> PokemonsToLevelUp => _settings.PokemonsToLevelUp;

--- a/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
@@ -243,10 +243,10 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 46)]
         public double EvolveKeptPokemonsAtStorageUsagePercentage = 90.0;
 
-        [DefaultValue(60)]
-        [Range(0, 250)]
+        [DefaultValue(120)]
+        [Range(0, 350)]
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 47)]
-        public int OrWhicheverFirst_EvolveKeptPokemonsAtThisNumber = 60;
+        public int EvolveKeptPokemonsOverrideStartIfThisManyReady = 120;
 
 
         /*Keep*/

--- a/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
@@ -243,56 +243,62 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 46)]
         public double EvolveKeptPokemonsAtStorageUsagePercentage = 90.0;
 
+        [DefaultValue(60)]
+        [Range(0, 250)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 47)]
+        public int OrWhicheverFirst_EvolveKeptPokemonsAtThisNumber = 60;
+
+
         /*Keep*/
         [DefaultValue(false)]
-        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 47)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 48)]
         public bool KeepPokemonsThatCanEvolve;
 
         [DefaultValue(1250)]
         [Range(0, 9999)]
-        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 48)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 49)]
         public int KeepMinCp = 1250;
 
         [DefaultValue(90)]
         [Range(0, 100)]
-        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 49)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 50)]
         public float KeepMinIvPercentage = 90;
 
         [DefaultValue(6)]
         [Range(0, 100)]
-        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 50)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 51)]
         public int KeepMinLvl = 6;
 
         [DefaultValue("or")]
         [EnumDataType(typeof(Operator))]
-        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 51)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 52)]
         public string KeepMinOperator = "or";
 
         [DefaultValue(false)]
-        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 52)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 53)]
         public bool UseKeepMinLvl;
 
         [DefaultValue(false)]
-        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 53)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 54)]
         public bool PrioritizeIvOverCp;
 
         [DefaultValue(1)]
         [Range(0, 999)]
-        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 54)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 55)]
         public int KeepMinDuplicatePokemon = 1;
 
         /*NotCatch*/
         [DefaultValue(false)]
-        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 55)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 56)]
         public bool UsePokemonToNotCatchFilter;
 
         [DefaultValue(false)]
-        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 56)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 57)]
         public bool UsePokemonSniperFilterOnly;
 
         /*Dump Stats*/
         [DefaultValue(false)]
-        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 57)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 58)]
         public bool DumpPokemonStats;
     }
 }

--- a/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
@@ -45,8 +45,8 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                     var pokemonNeededInInventory = (maxStorage - totalEggs.Count()) * session.LogicSettings.EvolveKeptPokemonsAtStorageUsagePercentage / 100.0f;
                     var needPokemonToStartEvolve = Math.Round(
-                        Math.Max(0,
-                            Math.Min(pokemonNeededInInventory, session.Profile.PlayerData.MaxPokemonStorage)));
+                        Math.Max(0, Math.Min(session.LogicSettings.OrWhicheverFirst_EvolveKeptPokemonsAtThisNumber,
+                            Math.Min(pokemonNeededInInventory, session.Profile.PlayerData.MaxPokemonStorage))));
 
                     var deltaCount = needPokemonToStartEvolve - totalPokemon.Count();
                     if (session.LogicSettings.UseLuckyEggsWhileEvolving)

--- a/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
@@ -45,7 +45,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                     var pokemonNeededInInventory = (maxStorage - totalEggs.Count()) * session.LogicSettings.EvolveKeptPokemonsAtStorageUsagePercentage / 100.0f;
                     var needPokemonToStartEvolve = Math.Round(
-                        Math.Max(0, Math.Min(session.LogicSettings.OrWhicheverFirst_EvolveKeptPokemonsAtThisNumber,
+                        Math.Max(0, Math.Min(session.LogicSettings.EvolveKeptPokemonsOverrideStartIfThisManyReady,
                             Math.Min(pokemonNeededInInventory, session.Profile.PlayerData.MaxPokemonStorage))));
 
                     var deltaCount = needPokemonToStartEvolve - totalPokemon.Count();


### PR DESCRIPTION
This issue was marked unnecesary already, but after the ban wave, a lot has changed. I see the code at this repository had nicely added separate setting for Evolve (Animation) Delay. This delay create a new behavior. Unlike the previous insta-evolve, now with default value supplied by "global.settings" at 30 second animation delay, then you got max 60 evolve for each lucky egg session. That's why they need this fixed number parameter. I've seen someone else asking for this same feature at other unmaintained repository branch. With random catch of pokemons, they find it difficult to guess a percentage that matched lucky egg time and evolve animation delay.

I just put half a line code in the evolve logic, so they start evolving when storage percentage reached, or when this number reached, whichever occur first. The rest of the change is just adjusting interfaces for the parameter to appear in config.json.

It's good to see that the config.json is very neat as compared to the previous one.
