### PR TITLE
Fixes elevation-related issues

### DIFF
--- a/PoGo.NecroBot.Logic/Service/Elevation/BaseElevationService.cs
+++ b/PoGo.NecroBot.Logic/Service/Elevation/BaseElevationService.cs
@@ -68,7 +68,11 @@ namespace PoGo.NecroBot.Logic.Service.Elevation
 
         public double GetRandomElevation(double elevation)
         {
-            return elevation + (new Random().NextDouble() * 5);
+            // Adds a random elevation to the retrieved one. This was
+            // previously set to 5 meters but since it's happening with
+            // just a few seconds in between it is deemed unrealistic. 
+            // Telling from real world examples ~1.2 meter fits better.
+            return elevation + (new Random().NextDouble() * 1.2);
         }
     }
 }

--- a/PoGo.NecroBot.Logic/Service/Elevation/ElevationService.cs
+++ b/PoGo.NecroBot.Logic/Service/Elevation/ElevationService.cs
@@ -26,7 +26,7 @@ namespace PoGo.NecroBot.Logic.Service.Elevation
         {
             // First try Google service
             double elevation = googleService.GetElevation(lat, lng);
-            if (elevation == 0)
+            if (elevation == 0 || elevation < -200)
             {
                 // Fallback to MapQuest service
                 elevation = mapQuestService.GetElevation(lat, lng);

--- a/PoGo.NecroBot.Logic/Service/Elevation/GoogleElevationService.cs
+++ b/PoGo.NecroBot.Logic/Service/Elevation/GoogleElevationService.cs
@@ -11,6 +11,7 @@ namespace PoGo.NecroBot.Logic.Service.Elevation
 {
     public class GoogleResponse
     {
+        public string status { get; set; }
         public List<GoogleElevationResults> results { get; set; }
     }
 
@@ -57,9 +58,16 @@ namespace PoGo.NecroBot.Logic.Service.Elevation
                     {
                         responseFromServer = reader.ReadToEnd();
                         GoogleResponse googleResponse = JsonConvert.DeserializeObject<GoogleResponse>(responseFromServer);
-                        if (googleResponse.results != null && 0 < googleResponse.results.Count)
+
+                        if (googleResponse.status == "OK")
                         {
-                            return googleResponse.results[0].elevation;
+                            if (googleResponse.results != null && 0 < googleResponse.results.Count)
+                                return googleResponse.results[0].elevation;
+                        }
+                        else
+                        {
+                            Logging.Logger.Write($"[REPLY] when accessing Google Elevation Service API: {googleResponse.status.ToString()}",
+                                Logging.LogLevel.Warning);
                         }
                     }
                 }

--- a/PoGo.NecroBot.Logic/Service/Elevation/MapQuestElevationService.cs
+++ b/PoGo.NecroBot.Logic/Service/Elevation/MapQuestElevationService.cs
@@ -55,9 +55,21 @@ namespace PoGo.NecroBot.Logic.Service.Elevation
                         responseFromServer = responseFromServer.Replace("handleHelloWorldResponse(", "");
                         responseFromServer = responseFromServer.Replace("]}});", "]}}");
                         MapQuestResponse mapQuestResponse = JsonConvert.DeserializeObject<MapQuestResponse>(responseFromServer);
-                        if (mapQuestResponse.elevationProfile != null && 0 < mapQuestResponse.elevationProfile.Count)
+                        if (mapQuestResponse.elevationProfile != null && 
+                            mapQuestResponse.elevationProfile.Count > 0 &&
+                            mapQuestResponse.elevationProfile[0].height > -100)
                         {
                             return mapQuestResponse.elevationProfile[0].height;
+                        }
+                        else
+                        {
+                            // Safeguard since values like -32000 has been frequently and consistently observed
+                            Logging.Logger.Write($"MapQuest Elevation response not reliable: {mapQuestResponse.elevationProfile[0].height.ToString()}",
+                                Logging.LogLevel.Warning);
+                            Logging.Logger.Write("Continuing without elevation-readings not recommended. Press any key to stop.",
+                                Logging.LogLevel.Warning);
+                            Console.ReadKey();
+                            Environment.Exit(0);
                         }
                     }
                 }


### PR DESCRIPTION
Added alert when Google Elevation API isn't working.
Also fixes bug where altitudes like -32000m were allowed and used.

It is said that the (real) client isn't sending altitudes (atm). Still might as well have these parts working.