### PR TITLE
Navigation enhancements - Mapzen strategy added

### DIFF
--- a/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
@@ -166,6 +166,10 @@ namespace PoGo.NecroBot.Logic.Interfaces.Configuration
         bool UseYoursWalk { get; }
         string YoursWalkHeuristic { get; }
 
+        bool UseMapzenWalk { get; }
+        string MapzenTurnByTurnApiKey { get; }
+        string MapzenWalkHeuristic { get; }
+
         int ResumeTrack { get; }
         int ResumeTrackSeg { get; }
         int ResumeTrackPt { get; }

--- a/PoGo.NecroBot.Logic/Model/Google/GoogleWalk.cs
+++ b/PoGo.NecroBot.Logic/Model/Google/GoogleWalk.cs
@@ -10,6 +10,7 @@ namespace PoGo.NecroBot.Logic.Model.Google
     public class GoogleWalk
     {
         public List<GeoCoordinate> Waypoints { get; set; }
+        public double Distance { get; set; }
 
         public GoogleWalk(GoogleResult googleResult)
         {
@@ -17,6 +18,8 @@ namespace PoGo.NecroBot.Logic.Model.Google
                 throw new ArgumentException("Invalid google route.");
 
             var route = googleResult.Directions.routes.First();
+
+            Distance = googleResult.GetDistance();
 
             Waypoints = new List<GeoCoordinate>();
             // In some cases, player are inside build

--- a/PoGo.NecroBot.Logic/Model/Mapzen/MapzenWalk.cs
+++ b/PoGo.NecroBot.Logic/Model/Mapzen/MapzenWalk.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using GeoCoordinatePortable;
+using Newtonsoft.Json;
+using PoGo.NecroBot.Logic.Model.Google.GoogleObjects;
+using Newtonsoft.Json.Serialization;
+using Newtonsoft.Json.Linq;
+using PoGo.NecroBot.Logic.Utils;
+using Newtonsoft.Json.Schema;
+using Newtonsoft.Json.Schema.Generation;
+
+namespace PoGo.NecroBot.Logic.Model.Mapzen
+{
+    public class Trip
+    {
+        public string language { get; set; }
+        public Summary summary { get; set; }
+        public int status { get; set; }
+        public string status_message { get; set; }
+        public string units { get; set; }
+        public List<Legs> legs { get; set; }
+        public List<Location> locations { get; set; }
+    }
+
+    public class Summary
+    {
+        public double max_lon { get; set; }
+        public double max_lat { get; set; }
+        public int time { get; set; }
+        public double length { get; set; }
+        public double min_lon { get; set; }
+        public double min_lat { get; set; }
+    }
+    
+    public class Location
+    {
+        public double lon { get; set; }
+        public double lat { get; set; }
+    }
+
+    public class Legs
+    {
+        public string shape { get; set; }
+        public Summary summary { get; set; }
+    }
+    
+    public class MapzenWalk
+    {
+        public List<GeoCoordinate> Waypoints { get; set; }
+        public double Distance { get; set; }
+        
+        public MapzenWalk(string mapzenResponse, GeoCoordinate sourceLocation, GeoCoordinate destLocation)
+        {
+            Waypoints = new List<GeoCoordinate>();
+
+            // Add the source
+            Waypoints.Add(sourceLocation);
+
+            JObject jsonObj = JObject.Parse(mapzenResponse);
+
+            var trip = jsonObj["trip"];
+            int status = (int)trip["status"];
+            if (status == 0)
+            {
+                JObject summary = (JObject)trip["summary"];
+                Distance = (double)summary["length"] * 1000;
+
+                JArray legs = (JArray)trip["legs"];
+                foreach (var leg in legs)
+                {
+                    string shape = (string)leg["shape"];
+
+                    // Decode the polyline.
+                    Waypoints.AddRange(DecodePoly(shape));
+                }
+            }
+
+            // Add the destination
+            Waypoints.Add(destLocation);
+        }
+
+        public List<GeoCoordinate> DecodePoly(string points, int precision = 6)
+        {
+            var poly = new List<GeoCoordinate>();
+            if (string.IsNullOrEmpty(points))
+                throw new ArgumentNullException("polyline");
+
+            char[] polylineChars = points.ToCharArray();
+            int index = 0;
+            double lat = 0;
+            double lng = 0;
+            double latitudeChange = 0;
+            double longitudeChange = 0;
+            int next5bits;
+            int sum;
+            int shifter;
+            double factor = Math.Pow(10, precision);
+            
+            while (index < polylineChars.Length)
+            {
+                // calculate next latitude
+                next5bits = 0;
+                sum = 0;
+                shifter = 0;
+                do
+                {
+                    next5bits = (int)polylineChars[index++] - 63;
+                    sum |= (next5bits & 0x1f) << shifter;
+                    shifter += 5;
+                } while (next5bits >= 0x20);
+
+                latitudeChange = (sum & 1) == 1 ? ~(sum >> 1) : (sum >> 1);
+
+                //calculate next longitude
+                next5bits = 0;
+                sum = 0;
+                shifter = 0;
+                do
+                {
+                    next5bits = (int)polylineChars[index++] - 63;
+                    sum |= (next5bits & 0x1f) << shifter;
+                    shifter += 5;
+                } while (next5bits >= 0x20);
+                
+                longitudeChange = (sum & 1) == 1 ? ~(sum >> 1) : (sum >> 1);
+
+                lat += latitudeChange;
+                lng += longitudeChange;
+
+                poly.Add(new GeoCoordinate()
+                {
+                    Latitude = lat / factor,
+                    Longitude = lng / factor
+                });
+            }
+
+            return poly;
+        }
+
+        public static MapzenWalk Get(string mapzenResponse, GeoCoordinate sourceLocation, GeoCoordinate destLocation)
+        {
+            return new MapzenWalk(mapzenResponse, sourceLocation, destLocation);
+        }
+    }
+}

--- a/PoGo.NecroBot.Logic/Model/Settings/GlobalSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/GlobalSettings.cs
@@ -80,6 +80,9 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public YoursWalkConfig YoursWalkConfig = new YoursWalkConfig();
 
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public MapzenWalkConfig MapzenWalkConfig = new MapzenWalkConfig();
+
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Ignore)]
         public List<ItemRecycleFilter> ItemRecycleFilter = Settings.ItemRecycleFilter.ItemRecycleFilterDefault();
 
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Ignore)]

--- a/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
@@ -142,6 +142,10 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public bool UseYoursWalk => _settings.YoursWalkConfig.UseYoursWalk;
         public string YoursWalkHeuristic => _settings.YoursWalkConfig.YoursWalkHeuristic;
 
+        public bool UseMapzenWalk => _settings.MapzenWalkConfig.UseMapzenWalk;
+        public string MapzenTurnByTurnApiKey => _settings.MapzenWalkConfig.MapzenTurnByTurnApiKey;
+        public string MapzenWalkHeuristic => _settings.MapzenWalkConfig.MapzenWalkHeuristic;
+
         public bool SnipeAtPokestops => _settings.SnipeConfig.SnipeAtPokestops;
         public bool ActivateMSniper => _settings.SnipeConfig.ActivateMSniper;
         public bool UseTelegramAPI => _settings.TelegramConfig.UseTelegramAPI;

--- a/PoGo.NecroBot.Logic/Model/Settings/MapzenWalkConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/MapzenWalkConfig.cs
@@ -1,0 +1,30 @@
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using Newtonsoft.Json;
+
+namespace PoGo.NecroBot.Logic.Model.Settings
+{
+    [JsonObject(Title = "MapzenWalk Config", Description = "Set your mapzenwalk settings.", ItemRequired = Required.DisallowNull)]
+    public class MapzenWalkConfig
+    {
+        internal enum MapzenWalkTravelModes
+        {
+            auto,
+            bicycle,
+            pedestrian
+        }
+
+        [DefaultValue(false)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 1)]
+        public bool UseMapzenWalk = false;
+
+        [DefaultValue(null)]
+        [JsonProperty(Required = Required.Default, DefaultValueHandling = DefaultValueHandling.Populate, Order = 2)]
+        public string MapzenTurnByTurnApiKey;
+
+        [DefaultValue("bicycle")]
+        [EnumDataType(typeof(MapzenWalkTravelModes))]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 3)]
+        public string MapzenWalkHeuristic = "bicycle";
+    }
+}

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -225,7 +225,9 @@
     <Compile Include="Model\Settings\UpdateConfig.cs" />
     <Compile Include="Model\Settings\UpgradeFilter.cs" />
     <Compile Include="Model\Settings\WebsocketsConfig.cs" />
+    <Compile Include="Model\Settings\MapzenWalkConfig.cs" />
     <Compile Include="Model\Settings\YoursWalkConfig.cs" />
+    <Compile Include="Model\Mapzen\MapzenWalk.cs" />
     <Compile Include="Model\Yours\YoursWalk.cs" />
     <Compile Include="Navigation.cs" />
     <Compile Include="PoGoUtils\PokemonInfo.cs" />
@@ -238,6 +240,7 @@
     <Compile Include="Service\Elevation\MapQuestElevationService.cs" />
     <Compile Include="Service\TelegramService.cs" />
     <Compile Include="Model\Settings\LogicSettings.cs" />
+    <Compile Include="Service\MapzenDirectionsService.cs" />
     <Compile Include="Service\YoursDirectionsService.cs" />
     <Compile Include="State\CheckTosState.cs" />
     <Compile Include="State\SessionStats.cs" />
@@ -247,6 +250,7 @@
     <Compile Include="Strategies\Walk\HumanPathWalkingStrategy.cs" />
     <Compile Include="Strategies\Walk\HumanStrategy.cs" />
     <Compile Include="Strategies\Walk\IWalkStrategy.cs" />
+    <Compile Include="Strategies\Walk\MapzenNavigationStrategy.cs" />
     <Compile Include="Strategies\Walk\YoursNavigationStrategy.cs" />
     <Compile Include="Tasks\EggsListTask.cs" />
     <Compile Include="Tasks\EvolveSpecificPokemonTask.cs" />

--- a/PoGo.NecroBot.Logic/Service/GoogleDirectionsService.cs
+++ b/PoGo.NecroBot.Logic/Service/GoogleDirectionsService.cs
@@ -23,56 +23,66 @@ namespace PoGo.NecroBot.Logic.Service
             OldResults = new List<GoogleResult>();
         }
 
-        public GoogleResult GetDirections(GeoCoordinate origin, List<GeoCoordinate> waypoints, GeoCoordinate destino)
+        public GoogleWalk GetDirections(GeoCoordinate origin, List<GeoCoordinate> waypoints, GeoCoordinate destino)
         {
-            if (_cache)
+            GoogleResult googleResult = null;
+            try
             {
-                var item = OldResults.FirstOrDefault(pesquisa => IsSameAdress(origin, waypoints, destino, pesquisa));
-                if (item != null)
+                if (_cache)
                 {
-                    item.FromCache = true;
-                    return item;
-                }
-            }
-            var url = GetUrl(origin, waypoints, destino);
-
-            using (var client = new HttpClient())
-            {
-                try
-                {
-                    client.BaseAddress = new Uri("https://maps.googleapis.com/maps/api/");
-                    client.DefaultRequestHeaders.Accept.Clear();
-                    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-
-                    HttpResponseMessage responseMessage = client.GetAsync(url).Result;
-                    var resposta = responseMessage.Content.ReadAsStringAsync();
-                    var google = JsonConvert.DeserializeObject<DirectionsResponse>(resposta.Result);
-                    if (google.status.Equals("OVER_QUERY_LIMIT"))
+                    var item = OldResults.FirstOrDefault(pesquisa => IsSameAdress(origin, waypoints, destino, pesquisa));
+                    if (item != null)
                     {
-                        // If we get an error, don't cache empty GoogleResult.  Just return null.
-                        return null;
+                        item.FromCache = true;
+                        googleResult = item;
                     }
-
-                    var resultadoPesquisa = new GoogleResult
-                    {
-                        Directions = google,
-                        RequestDate = DateTime.Now,
-                        Origin = origin,
-                        Waypoints = waypoints,
-                        Destiny = destino,
-                        FromCache = false,
-                    };
-
-                    if (_cache)
-                        SaveResult(resultadoPesquisa);
-
-                    return resultadoPesquisa;
                 }
-                catch(Exception)
+                else
                 {
-                    return null;
+                    var url = GetUrl(origin, waypoints, destino);
+
+                    using (var client = new HttpClient())
+                    {
+                        client.BaseAddress = new Uri("https://maps.googleapis.com/maps/api/");
+                        client.DefaultRequestHeaders.Accept.Clear();
+                        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+                        HttpResponseMessage responseMessage = client.GetAsync(url).Result;
+                        var resposta = responseMessage.Content.ReadAsStringAsync();
+                        var google = JsonConvert.DeserializeObject<DirectionsResponse>(resposta.Result);
+                        if (google.status.Equals("OVER_QUERY_LIMIT"))
+                        {
+                            // If we get an error, don't cache empty GoogleResult.  Just return null.
+                            return null;
+                        }
+
+                        var resultadoPesquisa = new GoogleResult
+                        {
+                            Directions = google,
+                            RequestDate = DateTime.Now,
+                            Origin = origin,
+                            Waypoints = waypoints,
+                            Destiny = destino,
+                            FromCache = false,
+                        };
+
+                        if (_cache)
+                            SaveResult(resultadoPesquisa);
+
+                        googleResult = resultadoPesquisa;
+                    }
+                }
+
+                if (googleResult != null)
+                {
+                    return GoogleWalk.Get(googleResult);
                 }
             }
+            catch(Exception)
+            {
+
+            }
+            return null;
         }
 
         private static bool IsSameAdress(GeoCoordinate origem, List<GeoCoordinate> waypoints, GeoCoordinate destino, GoogleResult googleSearch)

--- a/PoGo.NecroBot.Logic/Strategies/Walk/FlyStrategy.cs
+++ b/PoGo.NecroBot.Logic/Strategies/Walk/FlyStrategy.cs
@@ -23,6 +23,12 @@ namespace PoGo.NecroBot.Logic.Strategies.Walk
         {
             _client = client;
         }
+
+        public string GetWalkStrategyId()
+        {
+            return "Necrobot Flying";
+        }
+
         public async Task<PlayerUpdateResponse> Walk(GeoCoordinate targetLocation, Func<Task> functionExecutedWhileWalking, ISession session, CancellationToken cancellationToken, double walkSpeed = 0.0)
         {
             var curLocation = new GeoCoordinate(_client.CurrentLatitude, _client.CurrentLongitude);

--- a/PoGo.NecroBot.Logic/Strategies/Walk/HumanPathWalkingStrategy.cs
+++ b/PoGo.NecroBot.Logic/Strategies/Walk/HumanPathWalkingStrategy.cs
@@ -20,6 +20,11 @@ namespace PoGo.NecroBot.Logic.Strategies.Walk
             _client = client;
         }
 
+        public string GetWalkStrategyId()
+        {
+            return "NecroBot Gpx";
+        }
+
         public async Task<PlayerUpdateResponse> Walk(GeoCoordinate targetLocation, Func<Task> functionExecutedWhileWalking, ISession session, CancellationToken cancellationToken, double walkSpeed = 0.0)
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/PoGo.NecroBot.Logic/Strategies/Walk/HumanStrategy.cs
+++ b/PoGo.NecroBot.Logic/Strategies/Walk/HumanStrategy.cs
@@ -6,6 +6,7 @@ using PoGo.NecroBot.Logic.State;
 using PoGo.NecroBot.Logic.Utils;
 using PokemonGo.RocketAPI;
 using POGOProtos.Networking.Responses;
+using PoGo.NecroBot.Logic.Event;
 
 namespace PoGo.NecroBot.Logic.Strategies.Walk
 {
@@ -20,9 +21,18 @@ namespace PoGo.NecroBot.Logic.Strategies.Walk
             _client = client;
         }
 
+        public string GetWalkStrategyId()
+        {
+            return "NecroBot Walk";
+        }
+
         private const double SpeedDownTo = 10 / 3.6;
         public async Task<PlayerUpdateResponse> Walk(GeoCoordinate targetLocation, Func<Task> functionExecutedWhileWalking, ISession session, CancellationToken cancellationToken, double walkSpeed = 0.0)
         {
+            var distance = LocationUtils.CalculateDistanceInMeters(session.Client.CurrentLatitude,
+                        session.Client.CurrentLongitude, BaseWalkStrategy.FortInfo.Latitude, BaseWalkStrategy.FortInfo.Longitude);
+            session.EventDispatcher.Send(new FortTargetEvent { Name = BaseWalkStrategy.FortInfo.Name, Distance = distance, Route = GetWalkStrategyId() });
+
             if (CurrentWalkingSpeed <= 0)
                 CurrentWalkingSpeed = session.LogicSettings.WalkingSpeedInKilometerPerHour;
             if (session.LogicSettings.UseWalkingSpeedVariant && walkSpeed == 0)

--- a/PoGo.NecroBot.Logic/Strategies/Walk/IWalkStrategy.cs
+++ b/PoGo.NecroBot.Logic/Strategies/Walk/IWalkStrategy.cs
@@ -9,6 +9,7 @@ namespace PoGo.NecroBot.Logic.Strategies.Walk
 {
     public interface IWalkStrategy
     {
+        string GetWalkStrategyId();
         event UpdatePositionDelegate UpdatePositionEvent;
         Task<PlayerUpdateResponse> Walk(GeoCoordinate targetLocation, Func<Task> functionExecutedWhileWalking, ISession session, CancellationToken cancellationToken, double customWalkingSpeed = 0.0);
         double CalculateDistance(double sourceLat, double sourceLng, double destinationLat, double destinationLng, ISession session = null);

--- a/PoGo.NecroBot.Logic/Strategies/Walk/MapzenNavigationStrategy.cs
+++ b/PoGo.NecroBot.Logic/Strategies/Walk/MapzenNavigationStrategy.cs
@@ -7,46 +7,46 @@ using PoGo.NecroBot.Logic.Service;
 using PoGo.NecroBot.Logic.State;
 using PokemonGo.RocketAPI;
 using POGOProtos.Networking.Responses;
-using PoGo.NecroBot.Logic.Model.Yours;
+using PoGo.NecroBot.Logic.Model.Mapzen;
 using PoGo.NecroBot.Logic.Event;
 using PoGo.NecroBot.Logic.Utils;
 
 namespace PoGo.NecroBot.Logic.Strategies.Walk
 {
-    class YoursNavigationStrategy : BaseWalkStrategy, IWalkStrategy
+    class MapzenNavigationStrategy : BaseWalkStrategy, IWalkStrategy
     {
-        private YoursDirectionsService _yoursDirectionsService;
+        private MapzenDirectionsService _mapzenDirectionsService;
 
-        public YoursNavigationStrategy(Client client) : base(client)
+        public MapzenNavigationStrategy(Client client) : base(client)
         {
-            _yoursDirectionsService = null;
+            _mapzenDirectionsService = null;
         }
 
         public override string GetWalkStrategyId()
         {
-            return "Yours Walk";
+            return "Mapzen Walk";
         }
 
         public override async Task<PlayerUpdateResponse> Walk(GeoCoordinate targetLocation, Func<Task> functionExecutedWhileWalking, ISession session, CancellationToken cancellationToken, double walkSpeed = 0.0)
         {
-            GetYoursInstance(session);
+            GetMapzenInstance(session);
             var sourceLocation = new GeoCoordinate(_client.CurrentLatitude, _client.CurrentLongitude, _client.CurrentAltitude);
-            var yoursWalk = _yoursDirectionsService.GetDirections(sourceLocation, targetLocation);
+            MapzenWalk mapzenWalk = _mapzenDirectionsService.GetDirections(sourceLocation, targetLocation);
 
-            if (yoursWalk == null)
+            if (mapzenWalk == null)
             {
                 return await RedirectToNextFallbackStrategy(session.LogicSettings, targetLocation, functionExecutedWhileWalking, session, cancellationToken);
             }
             
-            session.EventDispatcher.Send(new FortTargetEvent { Name = FortInfo.Name, Distance = yoursWalk.Distance, Route = GetWalkStrategyId() });
-            List<GeoCoordinate> points = yoursWalk.Waypoints;
+            session.EventDispatcher.Send(new FortTargetEvent { Name = FortInfo.Name, Distance = mapzenWalk.Distance, Route = GetWalkStrategyId() });
+            List<GeoCoordinate> points = mapzenWalk.Waypoints;
             return await DoWalk(points, session, functionExecutedWhileWalking, sourceLocation, targetLocation, cancellationToken, walkSpeed);
         }
 
-        private void GetYoursInstance(ISession session)
+        private void GetMapzenInstance(ISession session)
         {
-            if (_yoursDirectionsService == null)
-                _yoursDirectionsService = new YoursDirectionsService(session);
+            if (_mapzenDirectionsService == null)
+                _mapzenDirectionsService = new MapzenDirectionsService(session);
         }
 
         public override double CalculateDistance(double sourceLat, double sourceLng, double destinationLat, double destinationLng, ISession session = null)
@@ -56,19 +56,19 @@ namespace PoGo.NecroBot.Logic.Strategies.Walk
 
             /*
             if (session != null)
-                GetYoursInstance(session);
+                GetMapzenInstance(session);
 
-            if (_yoursDirectionsService != null)
+            if (_mapzenDirectionsService != null)
             {
-                var yoursResult = _yoursDirectionsService.GetDirections(new GeoCoordinate(sourceLat, sourceLng), new GeoCoordinate(destinationLat, destinationLng));
-                if (string.IsNullOrEmpty(yoursResult) || yoursResult.StartsWith("<?xml version=\"1.0\"") || yoursResult.Contains("error"))
+                var mapzenResult = _mapzenDirectionsService.GetDirections(new GeoCoordinate(sourceLat, sourceLng), new GeoCoordinate(destinationLat, destinationLng));
+                if (string.IsNullOrEmpty(mapzenResult) || mapzenResult.StartsWith("<?xml version=\"1.0\"") || mapzenResult.Contains("error"))
                 {
                     return 1.5 * base.CalculateDistance(sourceLat, sourceLng, destinationLat, destinationLng);
                 }
                 else
                 {
-                    var yoursWalk = YoursWalk.Get(yoursResult);
-                    return yoursWalk.Distance;
+                    var mapzenWalk = MapzenWalk.Get(mapzenResult);
+                    return mapzenWalk.Distance;
                 }
             }
             else

--- a/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
@@ -166,10 +166,11 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if (!session.LogicSettings.UseGoogleWalk && !session.LogicSettings.UseYoursWalk)
-                    session.EventDispatcher.Send(new FortTargetEvent { Name = fortInfo.Name, Distance = distance, Route = "NecroBot" });
-                else
-                    BaseWalkStrategy.FortInfo = fortInfo;
+                session.EventDispatcher.Send(new FortTargetEvent { Name = fortInfo.Name, Distance = distance, Route = session.Navigation.GetStrategy(session.LogicSettings).GetWalkStrategyId() });
+
+                // Always set the fort info in base walk strategy.
+                BaseWalkStrategy.FortInfo = fortInfo;
+
                 var pokeStopDestination = new GeoCoordinate(pokeStop.Latitude, pokeStop.Longitude,
                     LocationUtils.getElevation(session, pokeStop.Latitude, pokeStop.Longitude));
 


### PR DESCRIPTION
## Short Description:
Navigation enhancements:
1) Better error handling and fallback - You should NEVER get a Google error again, even if you run out of requests for the day.
2) Blacklist for failing navigation strategies - It now has a priority queue that it goes through to find the next best strategy. If a strategy fails, it will be blacklisted for the next hour.  This is a performance fix also since previously it would keep hitting the failed service over and over, slowing down the bot.
Google -> Mapzen -> Yours -> Default Walking
3) Added Mapzen navigation strategy.  This is probably the best strategy since it has no daily limits once you have obtained a key, it looks pretty human, and it is fast and stable.

The human navigation strategies we support now are:
1) Google (requires a key)
2) Mapzen (requires a key)
3) YOURS (no key required)

Example of Mapzen Routing:
<img width="1167" alt="mapzen strategy" src="https://cloud.githubusercontent.com/assets/16908714/18457098/dacca362-790a-11e6-8460-67086dbd07cc.png">


## Fixes (provide links to github issues if you can):
#97 