### PR TITLE
Elevation enhancements - Add mapzen elevation service

### DIFF
--- a/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
@@ -162,6 +162,7 @@ namespace PoGo.NecroBot.Logic.Interfaces.Configuration
         bool UseGoogleWalkCache { get; }
         string GoogleApiKey { get; }
         string GoogleHeuristic { get; }
+        string GoogleElevationApiKey { get; }
 
         bool UseYoursWalk { get; }
         string YoursWalkHeuristic { get; }
@@ -169,6 +170,7 @@ namespace PoGo.NecroBot.Logic.Interfaces.Configuration
         bool UseMapzenWalk { get; }
         string MapzenTurnByTurnApiKey { get; }
         string MapzenWalkHeuristic { get; }
+        string MapzenElevationApiKey { get; }
 
         int ResumeTrack { get; }
         int ResumeTrackSeg { get; }

--- a/PoGo.NecroBot.Logic/Model/Settings/GoogleWalkConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/GoogleWalkConfig.cs
@@ -45,6 +45,13 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         [DefaultValue(true)]
         [JsonProperty("Cache", Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 5)]
         public bool Cache = true;
+
+        [DefaultValue(null)]
+        [MinLength(0)]
+        [MaxLength(64)]
+        [JsonProperty(Required = Required.Default, DefaultValueHandling = DefaultValueHandling.Populate, Order = 6)]
+        // This can be the same as the GoogleAPIKey, but if so then you need to activate Elevation API for the key.
+        public string GoogleElevationAPIKey;
     }
     
 }

--- a/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
@@ -138,6 +138,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public bool UseGoogleWalkCache => _settings.GoogleWalkConfig.Cache;
         public string GoogleApiKey => _settings.GoogleWalkConfig.GoogleAPIKey;
         public string GoogleHeuristic => _settings.GoogleWalkConfig.GoogleHeuristic;
+        public string GoogleElevationApiKey => _settings.GoogleWalkConfig.GoogleElevationAPIKey;
 
         public bool UseYoursWalk => _settings.YoursWalkConfig.UseYoursWalk;
         public string YoursWalkHeuristic => _settings.YoursWalkConfig.YoursWalkHeuristic;
@@ -145,6 +146,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public bool UseMapzenWalk => _settings.MapzenWalkConfig.UseMapzenWalk;
         public string MapzenTurnByTurnApiKey => _settings.MapzenWalkConfig.MapzenTurnByTurnApiKey;
         public string MapzenWalkHeuristic => _settings.MapzenWalkConfig.MapzenWalkHeuristic;
+        public string MapzenElevationApiKey => _settings.MapzenWalkConfig.MapzenElevationApiKey;
 
         public bool SnipeAtPokestops => _settings.SnipeConfig.SnipeAtPokestops;
         public bool ActivateMSniper => _settings.SnipeConfig.ActivateMSniper;

--- a/PoGo.NecroBot.Logic/Model/Settings/MapzenWalkConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/MapzenWalkConfig.cs
@@ -26,5 +26,9 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         [EnumDataType(typeof(MapzenWalkTravelModes))]
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 3)]
         public string MapzenWalkHeuristic = "bicycle";
+
+        [DefaultValue(null)]
+        [JsonProperty(Required = Required.Default, DefaultValueHandling = DefaultValueHandling.Populate, Order = 4)]
+        public string MapzenElevationApiKey;
     }
 }

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -235,6 +235,9 @@
     <Compile Include="Service\BotService.cs" />
     <Compile Include="Service\Elevation\BaseElevationService.cs" />
     <Compile Include="Service\Elevation\ElevationService.cs" />
+    <Compile Include="Service\Elevation\IElevationService.cs" />
+    <Compile Include="Service\Elevation\MapzenElevationService.cs" />
+    <Compile Include="Service\Elevation\RandomElevationService.cs" />
     <Compile Include="Service\GoogleDirectionsService.cs" />
     <Compile Include="Service\Elevation\GoogleElevationService.cs" />
     <Compile Include="Service\Elevation\MapQuestElevationService.cs" />

--- a/PoGo.NecroBot.Logic/Service/Elevation/BaseElevationService.cs
+++ b/PoGo.NecroBot.Logic/Service/Elevation/BaseElevationService.cs
@@ -2,19 +2,16 @@
 using GeoCoordinatePortable;
 using PoGo.NecroBot.Logic.State;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace PoGo.NecroBot.Logic.Service.Elevation
 {
-    public abstract class BaseElevationService
+    public abstract class BaseElevationService : IElevationService
     {
         protected ISession _session;
         protected LRUCache<string, double> _cache;
         protected string _apiKey;
 
+        public abstract string GetServiceId();
         public abstract double GetElevationFromWebService(double lat, double lng);
 
         public BaseElevationService(ISession session, LRUCache<string, double> cache)
@@ -41,10 +38,11 @@ namespace PoGo.NecroBot.Logic.Service.Elevation
             if (!success)
             {
                 elevation = GetElevationFromWebService(lat, lng);
-                if (elevation == 0)
+                if (elevation == 0 || elevation < -100)
                 {
-                    // Error getting elevation so just return 0.
-                    return 0;
+                    // Just return the elevation without caching.  Since this is invalid elevation, we want the 
+                    // elevation service to blacklist this service and move to the next one.
+                    return elevation;
                 }
                 else
                 {

--- a/PoGo.NecroBot.Logic/Service/Elevation/ElevationService.cs
+++ b/PoGo.NecroBot.Logic/Service/Elevation/ElevationService.cs
@@ -10,26 +10,71 @@ namespace PoGo.NecroBot.Logic.Service.Elevation
 {
     public class ElevationService
     {
-        private MapQuestElevationService mapQuestService;
-        private GoogleElevationService googleService;
         private ISession _session;
         LRUCache<string, double> cache = new LRUCache<string, double>(capacity: 500);
+
+        private List<IElevationService> ElevationServiceQueue = new List<IElevationService>();
+        public Dictionary<Type, DateTime> ElevationServiceBlacklist = new Dictionary<Type, DateTime>();
 
         public ElevationService(ISession session)
         {
             _session = session;
-            mapQuestService = new MapQuestElevationService(session, cache);
-            googleService = new GoogleElevationService(session, cache);
+
+            if (!string.IsNullOrEmpty(session.LogicSettings.MapzenElevationApiKey))
+                ElevationServiceQueue.Add(new MapzenElevationService(session, cache));
+
+            ElevationServiceQueue.Add(new MapQuestElevationService(session, cache));
+
+            if (!string.IsNullOrEmpty(session.LogicSettings.GoogleElevationApiKey))
+                ElevationServiceQueue.Add(new GoogleElevationService(session, cache));
+
+            ElevationServiceQueue.Add(new RandomElevationService(session, cache));
+        }
+
+        public bool IsElevationServiceBlacklisted(Type strategy)
+        {
+            if (!ElevationServiceBlacklist.ContainsKey(strategy))
+                return false;
+
+            DateTime now = DateTime.Now;
+            DateTime blacklistExpiresAt = ElevationServiceBlacklist[strategy];
+            if (blacklistExpiresAt < now)
+            {
+                // Blacklist expired
+                ElevationServiceBlacklist.Remove(strategy);
+                return false;
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        public void BlacklistStrategy(Type strategy)
+        {
+            // Black list for 1 hour.
+            ElevationServiceBlacklist[strategy] = DateTime.Now.AddHours(1);
+        }
+
+        public IElevationService GetService()
+        {
+            return ElevationServiceQueue.First(q => !IsElevationServiceBlacklisted(q.GetType()));
         }
 
         public double GetElevation(double lat, double lng)
         {
-            // First try Google service
-            double elevation = googleService.GetElevation(lat, lng);
-            if (elevation == 0 || elevation < -200)
+            IElevationService service = GetService();
+            double elevation = service.GetElevation(lat, lng);
+            if (elevation == 0 || elevation < -100)
             {
-                // Fallback to MapQuest service
-                elevation = mapQuestService.GetElevation(lat, lng);
+                // Error getting elevation so just return 0.
+                Logging.Logger.Write($"{service.GetServiceId()} response not reliable: {elevation.ToString()}, and will be blacklisted for one hour.", Logging.LogLevel.Warning);
+                BlacklistStrategy(service.GetType());
+
+                Logging.Logger.Write($"Falling back to next elevation strategy: {GetService().GetServiceId()}.", Logging.LogLevel.Warning);
+                
+                // After blacklisting, retry.
+                return GetElevation(lat, lng);
             }
 
             return elevation;

--- a/PoGo.NecroBot.Logic/Service/Elevation/IElevationService.cs
+++ b/PoGo.NecroBot.Logic/Service/Elevation/IElevationService.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GeoCoordinatePortable;
+using PoGo.NecroBot.Logic.State;
+using POGOProtos.Networking.Responses;
+
+namespace PoGo.NecroBot.Logic.Service.Elevation
+{
+    public interface IElevationService
+    {
+        string GetServiceId();
+        double GetElevation(double lat, double lng);
+    }
+}

--- a/PoGo.NecroBot.Logic/Service/Elevation/MapQuestElevationService.cs
+++ b/PoGo.NecroBot.Logic/Service/Elevation/MapQuestElevationService.cs
@@ -30,6 +30,11 @@ namespace PoGo.NecroBot.Logic.Service.Elevation
                 _apiKey = mapQuestDemoApiKey;
         }
 
+        public override string GetServiceId()
+        {
+            return "MapQuest Elevation Service";
+        }
+
         public override double GetElevationFromWebService(double lat, double lng)
         {
             if (string.IsNullOrEmpty(_apiKey))
@@ -61,16 +66,8 @@ namespace PoGo.NecroBot.Logic.Service.Elevation
                         {
                             return mapQuestResponse.elevationProfile[0].height;
                         }
-                        else
-                        {
-                            // Safeguard since values like -32000 has been frequently and consistently observed
-                            Logging.Logger.Write($"MapQuest Elevation response not reliable: {mapQuestResponse.elevationProfile[0].height.ToString()}",
-                                Logging.LogLevel.Warning);
-                            Logging.Logger.Write("Continuing without elevation-readings not recommended. Press any key to stop.",
-                                Logging.LogLevel.Warning);
-                            Console.ReadKey();
-                            Environment.Exit(0);
-                        }
+
+                        // All error handling is handled inside of the ElevationService.
                     }
                 }
             }

--- a/PoGo.NecroBot.Logic/Service/Elevation/RandomElevationService.cs
+++ b/PoGo.NecroBot.Logic/Service/Elevation/RandomElevationService.cs
@@ -1,0 +1,29 @@
+﻿using Caching;
+using GeoCoordinatePortable;
+using Newtonsoft.Json;
+using PoGo.NecroBot.Logic.State;
+using System;
+
+namespace PoGo.NecroBot.Logic.Service.Elevation
+{
+    public class RandomElevationService : BaseElevationService
+    {
+        private double minElevation = 5;
+        private double maxElevation = 50;
+        private Random rand = new Random();
+
+        public RandomElevationService(ISession session, LRUCache<string, double> cache) : base(session, cache)
+        {
+        }
+
+        public override string GetServiceId()
+        {
+            return "Random Elevation Service (Necrobot Default)";
+        }
+
+        public override double GetElevationFromWebService(double lat, double lng)
+        {
+            return rand.NextDouble() * (maxElevation - minElevation) + minElevation;
+        }
+    }
+}


### PR DESCRIPTION
## Short Description:
1) Added mapzen elevation service
2) Cleaned up the error handling and logic for elevation services.  If an elevation service returns a negative elevation, a very clear warning is shown, and then we fallback to the next service.

Priorities are:
Mapzen -> MapQuest -> Google -> Random (random elevation between 5 and 50)

Why this order?
1. Mapzen is fast and reliable once you get an API key. No daily limits
2. MapQuest does not require a key and for most users returns a good elevation value.
3. Google is last because I think using it for elevation uses up your quota for Google Directions API.