### PR TITLE
Add killswitch override prompt.  Now you can override killswitch. 

### DIFF
--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -306,6 +306,13 @@ namespace PoGo.NecroBot.CLI
                         {
                             Console.WriteLine(strReason + $"\n");
 
+							if (PromptForKillSwitchOverride())
+							{
+								// Override
+								Logger.Write("Overriding killswitch... you have been warned!", LogLevel.Warning);
+								return false;
+							}
+							
                             Logger.Write("The bot will now close, please press enter to continue", LogLevel.Error);
                             Console.ReadLine();
                             return true;
@@ -327,6 +334,28 @@ namespace PoGo.NecroBot.CLI
         {
             Logger.Write("Exception caught, writing LogBuffer.", force: true);
             throw new Exception();
+        }
+		
+        public static bool PromptForKillSwitchOverride()
+        {
+            Logger.Write("Do you want to override killswitch to bot at your own risk?", LogLevel.Warning);
+
+            while (true)
+            {
+                var strInput = Console.ReadLine().ToLower();
+
+                switch (strInput)
+                {
+                    case "y":
+                        // Override killswitch
+                        return true;
+                    case "n":
+                        return false;
+                    default:
+                        Logger.Write("Enter y or n", LogLevel.Error);
+                        continue;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Short Description:
Allows you to override kill switch.  If kill switch is active, it will prompt you if you want to override.

Bot at your own risk!

## Fixes (provide links to github issues if you can):