### PR TITLE
we should only store forts that is in user config range to session.forts

### DIFF
--- a/PoGo.NecroBot.Logic/State/Session.cs
+++ b/PoGo.NecroBot.Logic/State/Session.cs
@@ -32,9 +32,7 @@ namespace PoGo.NecroBot.Logic.State
         SessionStats Stats { get; }
         ElevationService ElevationService { get; }
         List<FortData> Forts { get; set; }
-        List<FortData> VisibleForts { get; set; }
         void AddForts(List<FortData> mapObjects);
-        void AddVisibleForts(List<FortData> mapObjects);
     }
 
 
@@ -47,8 +45,7 @@ namespace PoGo.NecroBot.Logic.State
 
         public Session(ISettings settings, ILogicSettings logicSettings, ITranslation translation)
         {
-            this.Forts = new List<FortData>();
-            this.VisibleForts = new List<FortData>();
+            Forts = new List<FortData>();
 
             EventDispatcher = new EventDispatcher();
             LogicSettings = logicSettings;
@@ -65,7 +62,6 @@ namespace PoGo.NecroBot.Logic.State
             Stats = new SessionStats();
         }
         public List<FortData> Forts { get; set; }
-        public List<FortData> VisibleForts { get; set; }
         public GlobalSettings GlobalSettings { get; set; }
 
         public ISettings Settings { get; set; }
@@ -97,29 +93,15 @@ namespace PoGo.NecroBot.Logic.State
             Inventory = new Inventory(Client, logicSettings);
             Navigation = new Navigation(Client, logicSettings);
         }
+
         public void AddForts(List<FortData> data)
         {
-            this.Forts.RemoveAll(p => data.Any(x => x.Id == p.Id && x.Type == FortType.Checkpoint));
-            this.Forts.AddRange(data.Where(x=> x.Type == FortType.Checkpoint));
-            foreach (var item in data.Where(p=>p.Type == FortType.Gym)) 
-            {
-                var exist = this.Forts.FirstOrDefault(x => x.Id == item.Id);
-                if(exist != null && exist.CooldownCompleteTimestampMs > DateTime.UtcNow.ToUnixTime()) {
-                    continue;
-                }
-                else
-                {
-                    this.Forts.RemoveAll(x => x.Id == item.Id);
-                    this.Forts.Add(item);
-                }
-            }
+            Forts.RemoveAll(p => data.Any(x =>
+                x.Id == p.Id &&
+                (x.Type == FortType.Checkpoint || x.Type == FortType.Gym)
+            ));
+            Forts.AddRange(data.Where(x => (x.Type == FortType.Checkpoint || x.Type == FortType.Gym)));
         }
 
-        public void AddVisibleForts(List<FortData> mapObjects)
-        {
-            var notexist = mapObjects.Where(p => !this.VisibleForts.Any(x => x.Id == p.Id));
-            this.VisibleForts.AddRange(notexist);
-
-        }
     }
 }

--- a/PoGo.NecroBot.Logic/Tasks/HumanWalkSnipeTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/HumanWalkSnipeTask.cs
@@ -248,7 +248,7 @@ namespace PoGo.NecroBot.Logic.Tasks
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var nearestStop = session.VisibleForts.OrderBy(i =>
+            var nearestStop = session.Forts.OrderBy(i =>
                 LocationUtils.CalculateDistanceInMeters(session.Client.CurrentLatitude,
                     session.Client.CurrentLongitude, i.Latitude, i.Longitude)).FirstOrDefault();
 
@@ -259,13 +259,10 @@ namespace PoGo.NecroBot.Logic.Tasks
                 {
                     await Task.Delay(3000, cancellationToken);
                     var nearbyPokeStops = await UseNearbyPokestopsTask.UpdateFortsData(session);
-                    var notexists = nearbyPokeStops.Where(p => !session.VisibleForts.Exists(x => x.Id == p.Id)).ToList();
-                    session.AddVisibleForts(notexists);
-                    session.EventDispatcher.Send(new PokeStopListEvent { Forts = notexists });
                     session.EventDispatcher.Send(new HumanWalkSnipeEvent
                     {
                         Type = HumanWalkSnipeEventTypes.PokestopUpdated,
-                        Pokestops = notexists,
+                        Pokestops = nearbyPokeStops,
                         NearestDistance = walkedDistance
                     });
                 }


### PR DESCRIPTION
We should only store forts within MaxTravelDistanceInMeters to
session.forts. It can prevent we call walk path api to useless
pokestops.
I also refine the code in UseNearbyPokestopsTask