### PR TITLE
Bug fix - Buffer console log until gui is loaded.

### DIFF
--- a/PoGo.NecroBot.CLI/WebSocketInterface.cs
+++ b/PoGo.NecroBot.CLI/WebSocketInterface.cs
@@ -127,6 +127,10 @@ namespace PoGo.NecroBot.CLI
             {
                 // ignored
             }
+
+            // When we first get a message from the web socket, turn off log buffering.
+            // This allows us to flush out buffered LogEvent messages to the GUI.
+            Logger.TurnOffLogBuffering();
         }
 
         private void HandleSession(WebSocketSession session)

--- a/PoGo.NecroBot.Logic/Logging/ILogger.cs
+++ b/PoGo.NecroBot.Logic/Logging/ILogger.cs
@@ -23,5 +23,6 @@ namespace PoGo.NecroBot.Logic.Logging
         /// <param name="color">Optional. Default automatic color.</param>
         void Write(string message, LogLevel level = LogLevel.Info, ConsoleColor color = ConsoleColor.Black);
         void lineSelect(int lineChar = 0, int linesUp = 1);
+        void TurnOffLogBuffering();
     }
 }

--- a/PoGo.NecroBot.Logic/Logging/Logger.cs
+++ b/PoGo.NecroBot.Logic/Logging/Logger.cs
@@ -18,6 +18,12 @@ namespace PoGo.NecroBot.Logic.Logging
         private static string _lastLogMessage;
         private static bool _isGui;
 
+        public static void TurnOffLogBuffering()
+        {
+            if (_logger != null)
+                _logger.TurnOffLogBuffering();
+        }
+
         private static void Log(string message, bool force = false)
         {
             lock (LogbufferList)

--- a/PoGo.NecroBot.Logic/Model/Settings/GlobalSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/GlobalSettings.cs
@@ -701,7 +701,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
 
         private static void SetupUserAccount(ITranslation translator, GlobalSettings settings)
         {
-            Console.WriteLine("");
+            Logger.Write("", LogLevel.Info);
             Logger.Write(translator.GetTranslation(TranslationString.FirstStartSetupUsernamePrompt), LogLevel.None);
             var strInput = Console.ReadLine();
 
@@ -711,7 +711,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
                 settings.Auth.AuthConfig.PtcUsername = strInput;
             Logger.Write(translator.GetTranslation(TranslationString.FirstStartSetupUsernameConfirm, strInput));
 
-            Console.WriteLine("");
+            Logger.Write("", LogLevel.Info);
             Logger.Write(translator.GetTranslation(TranslationString.FirstStartSetupPasswordPrompt), LogLevel.None);
             strInput = Console.ReadLine();
 

--- a/PoGo.NecroBot.Logic/State/VersionCheckState.cs
+++ b/PoGo.NecroBot.Logic/State/VersionCheckState.cs
@@ -95,7 +95,7 @@ namespace PoGo.NecroBot.Logic.State
             var tempPath = Path.Combine(baseDir, "tmp");
             var extractedDir = Path.Combine(tempPath, "NecroBot2.Console");
             var destinationDir = baseDir + Path.DirectorySeparatorChar;
-            Console.WriteLine(downloadLink);
+            Logger.Write(downloadLink, LogLevel.Info);
 
             if (!DownloadFile(downloadLink, downloadFilePath))
                 return new LoginState();
@@ -164,7 +164,7 @@ namespace PoGo.NecroBot.Logic.State
                 try
                 {
                     client.DownloadFile(url, dest);
-                    Console.WriteLine(dest);
+                    Logger.Write(dest, LogLevel.Info);
                 }
                 catch
                 {
@@ -275,7 +275,7 @@ namespace PoGo.NecroBot.Logic.State
 
             if( lstNewOptions != null && lstNewOptions.Count > 0 )
             {
-                Console.Write( "\n" );
+                Logger.Write( "\n", LogLevel.New);
                 Logger.Write( "### New Options found ###", LogLevel.New );
 
                 foreach( JProperty prop in lstNewOptions )
@@ -341,7 +341,7 @@ namespace PoGo.NecroBot.Logic.State
             }
             catch( Exception error )
             {
-                Console.WriteLine( error.Message );
+                Logger.Write( error.Message, LogLevel.Error );
             }
 
             return null;

--- a/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
@@ -70,7 +70,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                 {
                     if (session.Stats.PokeStopTimestamps[i] < TSminus24h)
                     {
-                        Console.WriteLine("Removing stored Pokestop timestamp {0}", session.Stats.PokeStopTimestamps[i]);
+                        Logger.Write($"Removing stored Pokestop timestamp {session.Stats.PokeStopTimestamps[i]}", LogLevel.Info);
                         session.Stats.PokeStopTimestamps.Remove(session.Stats.PokeStopTimestamps[i]);
                     }
                 }

--- a/PoGo.NecroBot.Logic/Utils/ErrorHandler.cs
+++ b/PoGo.NecroBot.Logic/Utils/ErrorHandler.cs
@@ -17,11 +17,11 @@ namespace PoGo.NecroBot.Logic.Utils
             if( strMessage != null)
                 Logger.Write( strMessage, level );
 
-            Console.Write( "Ending Application... " );
+            Logger.Write( "Ending Application... ", LogLevel.Error );
 
             for( int i = timeout; i > 0; i-- )
             {
-                Console.Write( "\b" + i );
+                Logger.Write( "\b" + i, LogLevel.Error );
                 System.Threading.Thread.Sleep( 1000 );
             }
 


### PR DESCRIPTION
## Short Description:
Bug fix for GUI missing some of the initial console log messages that were sent before the GUI connected to the bot.

Changes:

1. Replace all `Console.WriteLine` with `Logger.Write` to make sure messages go to both console and GUI console.
2. Add log buffering for console logger - Console is written to immediately but the messages are also buffered and output when the GUI has connected to the bot via websocket.