### PR TITLE
Bug fix for bot skipping pokestops

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
@@ -190,10 +190,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             //Catch Incense Pokemon
             await CatchIncensePokemonsTask.Execute(session, cancellationToken);
 
-            // Minor fix google route ignore pokestop
-            if (session.LogicSettings.UseGoogleWalk && 
-                !session.LogicSettings.UseYoursWalk && 
-                !session.LogicSettings.UseGpxPathing)
+            if (!session.LogicSettings.UseGpxPathing)
             {
                 // Spin as long as we haven't reached the user defined limits
                 if (!_pokestopLimitReached && !_pokestopTimerReached)


### PR DESCRIPTION
## Short Description:
Bug fix - Bot was skipping pokestops if you did not have Google walk enabled or you had YoursWalk enabled.

## Fixes (provide links to github issues if you can):
Fixes #184 
