### PR TITLE
Bug fix - Console not showing poke stop name.

### DIFF
--- a/PoGo.NecroBot.Logic/Model/IGeoLocation.cs
+++ b/PoGo.NecroBot.Logic/Model/IGeoLocation.cs
@@ -20,12 +20,13 @@ namespace PoGo.NecroBot.Logic.Model
     }
     public class FortLocation : MapLocation
     {
-         public FortData FortData { get; set; }
+        public FortData FortData { get; set; }
         public FortDetailsResponse FortInfo { get; set; }
         public FortLocation(double lat, double lng, double alt, FortData fortData, FortDetailsResponse fortInfo)  :base(lat, lng, alt)
         {
             this.FortData = fortData;
             this.FortInfo = fortInfo;
+            this.Name = fortInfo.Name;
         }
     }
     public class GPXPointLocation : MapLocation


### PR DESCRIPTION
## Short Description:
Poke stop location names were no longer being shown. This adds the poke stop name back to the FortLocation object so that it is shown in the console again.
