### PR TITLE
Fix pokestop spin bug (bug #213)

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
@@ -331,7 +331,9 @@ namespace PoGo.NecroBot.Logic.Tasks
 
         private static async Task FarmPokestop(ISession session, FortData pokeStop, FortDetailsResponse fortInfo, CancellationToken cancellationToken, bool doNotRetry = false)
         {
-            if (pokeStop.CooldownCompleteTimestampMs>  0 && pokeStop.CooldownCompleteTimestampMs < DateTime.UtcNow.ToUnixTime()) return;
+            // If the cooldown is in the future than don't farm the pokestop.
+            if (pokeStop.CooldownCompleteTimestampMs > DateTime.UtcNow.ToUnixTime())
+                return;
 
             FortSearchResponse fortSearch;
             var timesZeroXPawarded = 0;


### PR DESCRIPTION
## Short Description:
Fixes pokestop spin bug.  Skip poke stop when the cooldown is in the future.

## Fixes (provide links to github issues if you can):
#213 
