### PR TITLE
Bug fix - Fix #232 - Default altitude not set from elevation service.

### DIFF
--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -19,6 +19,7 @@ using PoGo.NecroBot.Logic.Service;
 using PoGo.NecroBot.Logic.State;
 using PoGo.NecroBot.Logic.Tasks;
 using PoGo.NecroBot.Logic.Utils;
+using PoGo.NecroBot.Logic.Service.Elevation;
 
 #endregion
 
@@ -198,15 +199,15 @@ namespace PoGo.NecroBot.CLI
                     settings.LocationConfig.ResumeTrackPt = nearestPt.PtIndex;
                 }
             }
-
-            _session = new Session(new ClientSettings(settings), logicSettings, translation);
+            IElevationService elevationService = new ElevationService(settings);
+            _session = new Session(new ClientSettings(settings, elevationService), logicSettings, elevationService, translation);
             Logger.SetLoggerContext(_session);
 
             if (boolNeedsSetup)
             {
                 if (GlobalSettings.PromptForSetup(_session.Translation))
                 {
-                    _session = GlobalSettings.SetupSettings(_session, settings, configFile);
+                    _session = GlobalSettings.SetupSettings(_session, settings, elevationService, configFile);
 
                     var fileName = Assembly.GetExecutingAssembly().Location;
                     Process.Start(fileName);

--- a/PoGo.NecroBot.Logic/Model/Settings/ClientSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/ClientSettings.cs
@@ -3,6 +3,7 @@ using PoGo.NecroBot.Logic.Utils;
 using PokemonGo.RocketAPI;
 using PokemonGo.RocketAPI.Enums;
 using Google.Protobuf;
+using PoGo.NecroBot.Logic.Service.Elevation;
 
 namespace PoGo.NecroBot.Logic.Model.Settings
 {
@@ -11,10 +12,12 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         // Never spawn at the same position.
         private readonly Random _rand = new Random();
         private readonly GlobalSettings _settings;
+        private readonly IElevationService _elevationService;
 
-        public ClientSettings(GlobalSettings settings)
+        public ClientSettings(GlobalSettings settings, IElevationService elevationService)
         {
             _settings = settings;
+            _elevationService = elevationService;
         }
 
 
@@ -210,13 +213,9 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         {
             get
             {
-                return
-                    LocationUtils.getElevation(null, _settings.LocationConfig.DefaultLatitude, _settings.LocationConfig.DefaultLongitude) +
-                    _rand.NextDouble() *
-                    ((double)5 / Math.Cos(LocationUtils.getElevation(null, _settings.LocationConfig.DefaultLatitude, _settings.LocationConfig.DefaultLongitude)));
+                return LocationUtils.getElevation(_elevationService, _settings.LocationConfig.DefaultLatitude, _settings.LocationConfig.DefaultLongitude);
             }
-
-
+            
             set { }
         }
     }

--- a/PoGo.NecroBot.Logic/Model/Settings/GlobalSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/GlobalSettings.cs
@@ -18,6 +18,7 @@ using PoGo.NecroBot.Logic.Logging;
 using PoGo.NecroBot.Logic.State;
 using PokemonGo.RocketAPI.Enums;
 using POGOProtos.Enums;
+using PoGo.NecroBot.Logic.Service.Elevation;
 
 #endregion
 
@@ -368,9 +369,9 @@ namespace PoGo.NecroBot.Logic.Model.Settings
             return promptForSetup;
         }
 
-        public static Session SetupSettings(Session session, GlobalSettings settings, string configPath)
+        public static Session SetupSettings(Session session, GlobalSettings settings, IElevationService elevationService, string configPath)
         {
-            var newSession = SetupTranslationCode(session, session.Translation, settings);
+            var newSession = SetupTranslationCode(session, elevationService, session.Translation, settings);
 
             SetupAccountType(newSession.Translation, settings);
             SetupUserAccount(newSession.Translation, settings);
@@ -387,7 +388,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
             return newSession;
         }
 
-        private static Session SetupTranslationCode(Session session, ITranslation translator, GlobalSettings settings)
+        private static Session SetupTranslationCode(Session session, IElevationService elevationService, ITranslation translator, GlobalSettings settings)
         {
             if (false == PromptForBoolean(translator, translator.GetTranslation(TranslationString.FirstStartLanguagePrompt, "Y", "N")))
                 return session;
@@ -395,7 +396,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
             string strInput = PromptForString(translator, translator.GetTranslation(TranslationString.FirstStartLanguageCodePrompt));
 
             settings.ConsoleConfig.TranslationLanguageCode = strInput;
-            session = new Session(new ClientSettings(settings), new LogicSettings(settings));
+            session = new Session(new ClientSettings(settings, elevationService), new LogicSettings(settings), elevationService);
             translator = session.Translation;
             Logger.Write(translator.GetTranslation(TranslationString.FirstStartLanguageConfirm, strInput));
 

--- a/PoGo.NecroBot.Logic/Service/Elevation/BaseElevationService.cs
+++ b/PoGo.NecroBot.Logic/Service/Elevation/BaseElevationService.cs
@@ -1,5 +1,6 @@
 ﻿using Caching;
 using GeoCoordinatePortable;
+using PoGo.NecroBot.Logic.Model.Settings;
 using PoGo.NecroBot.Logic.State;
 using System;
 
@@ -7,16 +8,16 @@ namespace PoGo.NecroBot.Logic.Service.Elevation
 {
     public abstract class BaseElevationService : IElevationService
     {
-        protected ISession _session;
+        protected GlobalSettings _settings;
         protected LRUCache<string, double> _cache;
         protected string _apiKey;
 
         public abstract string GetServiceId();
         public abstract double GetElevationFromWebService(double lat, double lng);
 
-        public BaseElevationService(ISession session, LRUCache<string, double> cache)
+        public BaseElevationService(GlobalSettings settings, LRUCache<string, double> cache)
         {
-            _session = session;
+            _settings = settings;
             _cache = cache;
         }
 

--- a/PoGo.NecroBot.Logic/Service/Elevation/ElevationService.cs
+++ b/PoGo.NecroBot.Logic/Service/Elevation/ElevationService.cs
@@ -1,34 +1,32 @@
 ﻿using Caching;
-using PoGo.NecroBot.Logic.State;
+using PoGo.NecroBot.Logic.Model.Settings;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace PoGo.NecroBot.Logic.Service.Elevation
 {
-    public class ElevationService
+    public class ElevationService : IElevationService
     {
-        private ISession _session;
+        private GlobalSettings _settings;
         LRUCache<string, double> cache = new LRUCache<string, double>(capacity: 500);
 
         private List<IElevationService> ElevationServiceQueue = new List<IElevationService>();
         public Dictionary<Type, DateTime> ElevationServiceBlacklist = new Dictionary<Type, DateTime>();
 
-        public ElevationService(ISession session)
+        public ElevationService(GlobalSettings settings)
         {
-            _session = session;
+            _settings = settings;
 
-            if (!string.IsNullOrEmpty(session.LogicSettings.MapzenElevationApiKey))
-                ElevationServiceQueue.Add(new MapzenElevationService(session, cache));
+            if (!string.IsNullOrEmpty(settings.MapzenWalkConfig.MapzenElevationApiKey))
+                ElevationServiceQueue.Add(new MapzenElevationService(settings, cache));
 
-            ElevationServiceQueue.Add(new MapQuestElevationService(session, cache));
+            ElevationServiceQueue.Add(new MapQuestElevationService(settings, cache));
 
-            if (!string.IsNullOrEmpty(session.LogicSettings.GoogleElevationApiKey))
-                ElevationServiceQueue.Add(new GoogleElevationService(session, cache));
+            if (!string.IsNullOrEmpty(settings.GoogleWalkConfig.GoogleElevationAPIKey))
+                ElevationServiceQueue.Add(new GoogleElevationService(settings, cache));
 
-            ElevationServiceQueue.Add(new RandomElevationService(session, cache));
+            ElevationServiceQueue.Add(new RandomElevationService(settings, cache));
         }
 
         public bool IsElevationServiceBlacklisted(Type strategy)
@@ -79,7 +77,11 @@ namespace PoGo.NecroBot.Logic.Service.Elevation
 
             return elevation;
         }
+
+        public string GetServiceId()
+        {
+            IElevationService service = GetService();
+            return service.GetServiceId();
+        }
     }
-
-
 }

--- a/PoGo.NecroBot.Logic/Service/Elevation/GoogleElevationService.cs
+++ b/PoGo.NecroBot.Logic/Service/Elevation/GoogleElevationService.cs
@@ -1,7 +1,6 @@
 ﻿using Caching;
-using GeoCoordinatePortable;
 using Newtonsoft.Json;
-using PoGo.NecroBot.Logic.State;
+using PoGo.NecroBot.Logic.Model.Settings;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -30,10 +29,10 @@ namespace PoGo.NecroBot.Logic.Service.Elevation
 
     public class GoogleElevationService : BaseElevationService
     {
-        public GoogleElevationService(ISession session, LRUCache<string, double> cache) : base(session, cache)
+        public GoogleElevationService(GlobalSettings settings, LRUCache<string, double> cache) : base(settings, cache)
         {
-            if (!string.IsNullOrEmpty(session.LogicSettings.GoogleElevationApiKey))
-                _apiKey = session.LogicSettings.GoogleElevationApiKey;
+            if (!string.IsNullOrEmpty(settings.GoogleWalkConfig.GoogleElevationAPIKey))
+                _apiKey = settings.GoogleWalkConfig.GoogleElevationAPIKey;
         }
 
         public override string GetServiceId()

--- a/PoGo.NecroBot.Logic/Service/Elevation/IElevationService.cs
+++ b/PoGo.NecroBot.Logic/Service/Elevation/IElevationService.cs
@@ -1,10 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using GeoCoordinatePortable;
-using PoGo.NecroBot.Logic.State;
-using POGOProtos.Networking.Responses;
-
 namespace PoGo.NecroBot.Logic.Service.Elevation
 {
     public interface IElevationService

--- a/PoGo.NecroBot.Logic/Service/Elevation/MapQuestElevationService.cs
+++ b/PoGo.NecroBot.Logic/Service/Elevation/MapQuestElevationService.cs
@@ -1,7 +1,6 @@
 ﻿using Caching;
-using GeoCoordinatePortable;
 using Newtonsoft.Json;
-using PoGo.NecroBot.Logic.State;
+using PoGo.NecroBot.Logic.Model.Settings;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -24,7 +23,7 @@ namespace PoGo.NecroBot.Logic.Service.Elevation
     {
         private string mapQuestDemoApiKey = $"Kmjtd|luua2qu7n9,7a=o5-lzbgq";
 
-        public MapQuestElevationService(ISession session, LRUCache<string, double> cache) : base(session, cache)
+        public MapQuestElevationService(GlobalSettings settings, LRUCache<string, double> cache) : base(settings, cache)
         {
             if (!string.IsNullOrEmpty(mapQuestDemoApiKey))
                 _apiKey = mapQuestDemoApiKey;

--- a/PoGo.NecroBot.Logic/Service/Elevation/MapzenElevationService.cs
+++ b/PoGo.NecroBot.Logic/Service/Elevation/MapzenElevationService.cs
@@ -1,10 +1,7 @@
 ﻿using Caching;
-using GeoCoordinatePortable;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using PoGo.NecroBot.Logic.State;
+using PoGo.NecroBot.Logic.Model.Settings;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Net;
 
@@ -12,10 +9,10 @@ namespace PoGo.NecroBot.Logic.Service.Elevation
 {
     public class MapzenElevationService : BaseElevationService
     {
-        public MapzenElevationService(ISession session, LRUCache<string, double> cache) : base(session, cache)
+        public MapzenElevationService(GlobalSettings settings, LRUCache<string, double> cache) : base(settings, cache)
         {
-            if (!string.IsNullOrEmpty(session.LogicSettings.MapzenElevationApiKey))
-                _apiKey = session.LogicSettings.MapzenElevationApiKey;
+            if (!string.IsNullOrEmpty(settings.MapzenWalkConfig.MapzenElevationApiKey))
+                _apiKey = settings.MapzenWalkConfig.MapzenElevationApiKey;
         }
 
         public override string GetServiceId()

--- a/PoGo.NecroBot.Logic/Service/Elevation/RandomElevationService.cs
+++ b/PoGo.NecroBot.Logic/Service/Elevation/RandomElevationService.cs
@@ -1,7 +1,5 @@
 ﻿using Caching;
-using GeoCoordinatePortable;
-using Newtonsoft.Json;
-using PoGo.NecroBot.Logic.State;
+using PoGo.NecroBot.Logic.Model.Settings;
 using System;
 
 namespace PoGo.NecroBot.Logic.Service.Elevation
@@ -12,7 +10,7 @@ namespace PoGo.NecroBot.Logic.Service.Elevation
         private double maxElevation = 50;
         private Random rand = new Random();
 
-        public RandomElevationService(ISession session, LRUCache<string, double> cache) : base(session, cache)
+        public RandomElevationService(GlobalSettings settings, LRUCache<string, double> cache) : base(settings, cache)
         {
         }
 

--- a/PoGo.NecroBot.Logic/State/Session.cs
+++ b/PoGo.NecroBot.Logic/State/Session.cs
@@ -31,7 +31,7 @@ namespace PoGo.NecroBot.Logic.State
         IEventDispatcher EventDispatcher { get; }
         TelegramService Telegram { get; set; }
         SessionStats Stats { get; }
-        ElevationService ElevationService { get; }
+        IElevationService ElevationService { get; set; }
         List<FortData> Forts { get; set; }
         List<FortData> VisibleForts { get; set; }
         void AddForts(List<FortData> mapObjects);
@@ -43,12 +43,12 @@ namespace PoGo.NecroBot.Logic.State
 
     public class Session : ISession
     {
-        public Session(ISettings settings, ILogicSettings logicSettings) : this(settings, logicSettings, Common.Translation.Load(logicSettings))
+        public Session(ISettings settings, ILogicSettings logicSettings, IElevationService elevationService) : this(settings, logicSettings, elevationService, Common.Translation.Load(logicSettings))
         {
 
         }
         public List<BotActions> Actions { get { return this.botActions; } }
-        public Session(ISettings settings, ILogicSettings logicSettings, ITranslation translation)
+        public Session(ISettings settings, ILogicSettings logicSettings, IElevationService elevationService, ITranslation translation)
         {
             this.Forts = new List<FortData>();
             this.VisibleForts = new List<FortData>();
@@ -56,11 +56,8 @@ namespace PoGo.NecroBot.Logic.State
             EventDispatcher = new EventDispatcher();
             LogicSettings = logicSettings;
 
-            ElevationService = new ElevationService(this);
-
-            // Update current altitude before assigning settings.
-            settings.DefaultAltitude = ElevationService.GetElevation(settings.DefaultLatitude, settings.DefaultLongitude);
-
+            this.ElevationService = elevationService;
+            
             Settings = settings;
 
             Translation = translation;
@@ -90,7 +87,7 @@ namespace PoGo.NecroBot.Logic.State
 
         public SessionStats Stats { get; set; }
 
-        public ElevationService ElevationService { get; }
+        public IElevationService ElevationService { get; set; }
 
         private List<BotActions> botActions = new List<BotActions>();
         public void Reset(ISettings settings, ILogicSettings logicSettings)

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
@@ -81,7 +81,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                         var lat = Convert.ToDouble(trackPoints.ElementAt(curTrkPt).Lat, CultureInfo.InvariantCulture);
                         var lng = Convert.ToDouble(trackPoints.ElementAt(curTrkPt).Lon, CultureInfo.InvariantCulture);
 
-                        IGeoLocation destination = new GPXPointLocation(lat, lng, LocationUtils.getElevation(session, lat, lng));
+                        IGeoLocation destination = new GPXPointLocation(lat, lng, LocationUtils.getElevation(session.ElevationService, lat, lng));
 
                         await session.Navigation.Move(destination,
                             async () =>

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
@@ -44,7 +44,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                 var defaultLocation = new MapLocation(session.Settings.DefaultLatitude,
                     session.Settings.DefaultLongitude,
-                    LocationUtils.getElevation(session, session.Settings.DefaultLatitude, session.Settings.DefaultLongitude)
+                    LocationUtils.getElevation(session.ElevationService, session.Settings.DefaultLatitude, session.Settings.DefaultLongitude)
                 );
 
                 await session.Navigation.Move(defaultLocation,

--- a/PoGo.NecroBot.Logic/Tasks/HumanWalkSnipeTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/HumanWalkSnipeTask.cs
@@ -195,7 +195,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                         Rarity = PokemonGradeHelper.GetPokemonGrade(pokemon.PokemonId).ToString()
                     });
                     var snipeTarget = new SnipeLocation(pokemon.Latitude, pokemon.Longitude,
-                           LocationUtils.getElevation(session, pokemon.Latitude, pokemon.Longitude));
+                           LocationUtils.getElevation(session.ElevationService, pokemon.Latitude, pokemon.Longitude));
 
                     await session.Navigation.Move(snipeTarget,
                         async () =>
@@ -245,7 +245,7 @@ namespace PoGo.NecroBot.Logic.Tasks
         private static async Task WalkingBackGPXPath(ISession session, CancellationToken cancellationToken, FortData originalPokestop)
         {
             var destination = new FortLocation(originalPokestop.Latitude, originalPokestop.Longitude,
-                         LocationUtils.getElevation(session, originalPokestop.Latitude, originalPokestop.Longitude), originalPokestop, null);
+                         LocationUtils.getElevation(session.ElevationService, originalPokestop.Latitude, originalPokestop.Longitude), originalPokestop, null);
             await session.Navigation.Move(destination,
                async () =>
                {

--- a/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
@@ -165,7 +165,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                 // Always set the fort info in base walk strategy.
 
                 var pokeStopDestination = new FortLocation(pokeStop.Latitude, pokeStop.Longitude,
-                    LocationUtils.getElevation(session, pokeStop.Latitude, pokeStop.Longitude), pokeStop, fortInfo);
+                    LocationUtils.getElevation(session.ElevationService, pokeStop.Latitude, pokeStop.Longitude), pokeStop, fortInfo);
 
                 await session.Navigation.Move(pokeStopDestination,
                  async () =>

--- a/PoGo.NecroBot.Logic/Utils/LocationUtils.cs
+++ b/PoGo.NecroBot.Logic/Utils/LocationUtils.cs
@@ -7,6 +7,7 @@ using POGOProtos.Networking.Responses;
 using PoGo.NecroBot.Logic.State;
 using PokemonGo.RocketAPI;
 using PoGo.NecroBot.Logic.Service;
+using PoGo.NecroBot.Logic.Service.Elevation;
 
 #endregion
 
@@ -36,10 +37,10 @@ namespace PoGo.NecroBot.Logic.Utils
                 destinationLocation.Latitude, destinationLocation.Longitude);
         }
 
-        public static double getElevation(ISession session, double lat, double lon)
+        public static double getElevation(IElevationService elevationService, double lat, double lon)
         {
-            if (session != null)
-                return session.ElevationService.GetElevation(lat, lon);
+            if (elevationService != null)
+                return elevationService.GetElevation(lat, lon);
 
             Random random = new Random();
             double maximum = 11.0f;


### PR DESCRIPTION
## Short Description:

- Elevation services needs to be created before session is created in order for settings to be able to access elevation service.
- Elevation services now no longer need session but instead simply require the `GlobalSettings` object in order to look up the API keys from settings.

## Fixes (provide links to github issues if you can):
#232 
