### PR TITLE
Bug fix #244 - By default add regional pokemon to PokemonsToIgnore list

### DIFF
--- a/PoGo.NecroBot.Logic/Model/Settings/CatchConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/CatchConfig.cs
@@ -18,7 +18,12 @@ namespace PoGo.NecroBot.Logic.Model.Settings
                 PokemonId.Rattata,
                 PokemonId.Spearow,
                 PokemonId.Zubat,
-                PokemonId.Doduo
+                PokemonId.Doduo,
+                //criteria: regional
+                PokemonId.Tauros,
+                PokemonId.Kangaskhan,
+                PokemonId.MrMime,
+                PokemonId.Farfetchd
             };
         }
 

--- a/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
@@ -282,13 +282,13 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public int KeepMinDuplicatePokemon = 1;
 
         /*NotCatch*/
-        [DefaultValue(false)]
+        [DefaultValue(true)]
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 55)]
-        public bool UsePokemonToNotCatchFilter;
+        public bool UsePokemonToNotCatchFilter = true;
 
-        [DefaultValue(false)]
+        [DefaultValue(true)]
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 56)]
-        public bool UsePokemonSniperFilterOnly;
+        public bool UsePokemonSniperFilterOnly = true;
 
         /*Dump Stats*/
         [DefaultValue(false)]


### PR DESCRIPTION
## Short Description:
This is a ban precaution. 

- Regional pokemon should be added by default to ```PokemonsToIgnore``` list.
- `UsePokemonToNotCatchFilter` set to true by default.
- `UsePokemonSniperFilterOnly` set to true by default.

## Fixes (provide links to github issues if you can):
#244 