### PR TITLE
Fix bug #202 - MSniper sniped pokemon should count against limits.

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
@@ -107,6 +107,9 @@ namespace PoGo.NecroBot.Logic.Tasks
         // ## From SnipePokemonTask
         // await CatchPokemonTask.Execute(session, cancellationToken, encounter, pokemon, currentFortData: null, sessionAllowTransfer: true);
 
+        // ## From MSniperServiceTask
+        // await CatchPokemonTask.Execute(session, cancellationToken, encounter, pokemon, currentFortData: null, sessionAllowTransfer: true);
+
         public static async Task Execute(ISession session, 
                                         CancellationToken cancellationToken, 
                                         dynamic encounter, 
@@ -202,7 +205,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                     EncounterId = _encounterId.ToString(),
                     Move1 = PokemonInfo.GetPokemonMove1(encounteredPokemon).ToString(),
                     Move2 = PokemonInfo.GetPokemonMove2(encounteredPokemon).ToString(),
-            });
+                });
 
                 CatchPokemonResponse caughtPokemonResponse = null;
                 var lastThrow = CatchPokemonResponse.Types.CatchStatus.CatchSuccess; // Initializing lastThrow

--- a/PoGo.NecroBot.Logic/Tasks/MSniperServiceTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/MSniperServiceTask.cs
@@ -135,86 +135,53 @@ namespace PoGo.NecroBot.Logic.Tasks
 
         public static async Task CatchFromService(ISession session, CancellationToken cancellationToken, EncounterInfo encounterId)
         {
-            //default to excellent throw
-            var normalizedRecticleSize = 1.95;
-            //default spin
-            var spinModifier = 1.0;
+            cancellationToken.ThrowIfCancellationRequested();
 
-            //round to 2 decimals
-            normalizedRecticleSize = Math.Round(normalizedRecticleSize, 2);
-
-            CatchPokemonResponse caughtPokemonResponse;
             double lat = session.Client.CurrentLatitude;
             double lon = session.Client.CurrentLongitude;
-            CatchPokemonResponse.Types.CatchStatus lastThrow = CatchPokemonResponse.Types.CatchStatus.CatchSuccess;
-            CatchPokemonTask.AmountOfBerries = 0;
-            do
+
+            EncounterResponse encounter;
+            try
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
                 await LocationUtils.UpdatePlayerLocationWithAltitude(session,
-                    new GeoCoordinate(encounterId.Latitude, encounterId.Longitude, session.Client.CurrentAltitude), 0); // Speed set to 0 for random speed.
+                   new GeoCoordinate(encounterId.Latitude, encounterId.Longitude, session.Client.CurrentAltitude), 0); // Speed set to 0 for random speed.
 
                 await Task.Delay(1000, cancellationToken);
 
-                var encounter = await session.Client.Encounter.EncounterPokemon(encounterId.EncounterId, encounterId.SpawnPointId);
+                encounter = await session.Client.Encounter.EncounterPokemon(encounterId.EncounterId, encounterId.SpawnPointId);
 
                 await Task.Delay(1000, cancellationToken);
-
+            }
+            finally
+            {
                 await LocationUtils.UpdatePlayerLocationWithAltitude(session,
                     new GeoCoordinate(lat, lon, session.Client.CurrentAltitude), 0);  // Speed set to 0 for random speed.
+            }
+            
+            PokemonData encounteredPokemon;
 
-                PokemonData encounteredPokemon;
+            // Catch if it's a WildPokemon (MSniping not allowed for Incense pokemons)
+            if (encounter?.Status == EncounterResponse.Types.Status.EncounterSuccess)
+            {
+                encounteredPokemon = encounter.WildPokemon?.PokemonData;
+            }
+            else
+            {
+                Logger.Write($"Pokemon despawned or wrong link format!", LogLevel.Service, ConsoleColor.Gray);
+                return;// No success to work with
+            }
 
-                // Catch if it's a WildPokemon (MSniping not allowed for Incense pokemons)
-                if (encounter is EncounterResponse && (encounter?.Status == EncounterResponse.Types.Status.EncounterSuccess))
-                {
-                    encounteredPokemon = encounter.WildPokemon?.PokemonData;
-                }
-                else
-                {
-                    Logger.Write($"Pokemon despawned or wrong link format!", LogLevel.Service, ConsoleColor.Gray);
-                    return;// No success to work with
-                }
+            var pokemon = new MapPokemon
+            {
+                EncounterId = encounterId.EncounterId,
+                ExpirationTimestampMs = encounterId.TimeTillHiddenMs,
+                Latitude = encounterId.Latitude,
+                Longitude = encounterId.Longitude,
+                PokemonId = encounteredPokemon.PokemonId,
+                SpawnPointId = encounterId.SpawnPointId
+            };
 
-
-                float probability = encounter.CaptureProbability.CaptureProbability_[0];
-                int cp = encounter.WildPokemon.PokemonData.Cp;
-                int maxcp = PokemonInfo.CalculateMaxCp(encounter.WildPokemon.PokemonData);
-                double lvl = PokemonInfo.GetLevel(encounter.WildPokemon.PokemonData);
-                var bestBall = await CatchPokemonTask.GetBestBall(session, encounteredPokemon, probability);
-
-                if (((session.LogicSettings.UseBerriesOperator.ToLower().Equals("and") &&
-                       encounterId.Iv >= session.LogicSettings.UseBerriesMinIv &&
-                       cp >= session.LogicSettings.UseBerriesMinCp &&
-                       probability < session.LogicSettings.UseBerriesBelowCatchProbability) ||
-                   (session.LogicSettings.UseBerriesOperator.ToLower().Equals("or") && (
-                       encounterId.Iv >= session.LogicSettings.UseBerriesMinIv ||
-                       cp >= session.LogicSettings.UseBerriesMinCp ||
-                       probability < session.LogicSettings.UseBerriesBelowCatchProbability))) &&
-                   lastThrow != CatchPokemonResponse.Types.CatchStatus.CatchMissed) // if last throw is a miss, no double berry
-                {
-
-                    CatchPokemonTask.AmountOfBerries++;
-                    if (CatchPokemonTask.AmountOfBerries <= session.LogicSettings.MaxBerriesToUsePerPokemon)
-                    {
-                        await CatchPokemonTask.UseBerry(session,
-                           encounter.WildPokemon.EncounterId,
-                           encounter.WildPokemon.SpawnPointId);
-                    }
-
-                }
-
-                caughtPokemonResponse = await session.Client.Encounter.CatchPokemon(encounterId.EncounterId, encounterId.SpawnPointId,
-                    bestBall, normalizedRecticleSize, spinModifier, true);
-
-
-                Logger.Write($"({caughtPokemonResponse.Status.ToString()})  {encounterId.PokemonId.ToString()}  IV: {encounterId.Iv}%  Lvl: {lvl}  CP: ({cp}/{maxcp})", LogLevel.Service, caughtPokemonResponse.Status == CatchPokemonResponse.Types.CatchStatus.CatchSuccess ? ConsoleColor.Green : ConsoleColor.Red);
-                //CatchPokemonTask.AmountOfBerries
-                await Task.Delay(1000, cancellationToken);
-                lastThrow = caughtPokemonResponse.Status;
-            } while (lastThrow == CatchPokemonResponse.Types.CatchStatus.CatchMissed || lastThrow == CatchPokemonResponse.Types.CatchStatus.CatchEscape);
-
+            await CatchPokemonTask.Execute(session, cancellationToken, encounter, pokemon, currentFortData: null, sessionAllowTransfer: true);
         }
 
         public static List<EncounterInfo> FindNew(List<EncounterInfo> received)


### PR DESCRIPTION
## Short Description:
Cleans up the MSniperServiceTask to re-use the same `CatchPokemonTask` logic that is used elsewhere when catching pokemon.  A lot of the code duplication is now gone.

@msx752 Please take a look and make sure everything looks good.

Testing with changes seems to be working:
<img width="638" alt="screen shot 2016-09-21 at 2 07 49 pm" src="https://cloud.githubusercontent.com/assets/16908714/18729107/35145b70-8005-11e6-82df-dfe5c6052679.png">

## Fixes (provide links to github issues if you can):
#202 
