### PR TITLE
Fix bug #251 - Check for null before setting location name.

### DIFF
--- a/PoGo.NecroBot.Logic/Model/IGeoLocation.cs
+++ b/PoGo.NecroBot.Logic/Model/IGeoLocation.cs
@@ -25,8 +25,12 @@ namespace PoGo.NecroBot.Logic.Model
         public FortLocation(double lat, double lng, double alt, FortData fortData, FortDetailsResponse fortInfo)  :base(lat, lng, alt)
         {
             this.FortData = fortData;
-            this.FortInfo = fortInfo;
-            this.Name = fortInfo.Name;
+
+            if (fortInfo != null)
+            {
+                this.FortInfo = fortInfo;
+                this.Name = fortInfo.Name;
+            }
         }
     }
     public class GPXPointLocation : MapLocation


### PR DESCRIPTION
## Short Description:
When walking back to GPX coordinates, there is no name for the location.  So we need to check for null `fortInfo` before using it.  

## Fixes (provide links to github issues if you can):
#251 
