### PR TITLE
Fix bug #215 - Continue to walk pokestops when hit pokestop limit

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
@@ -292,6 +292,12 @@ namespace PoGo.NecroBot.Logic.Tasks
             {
                 await FarmPokestop(session, pokeStop, fortInfo, cancellationToken, doNotTrySpin);
             }
+            else
+            {
+                // We hit the pokestop limit but not the pokemon limit. So we want to set the cooldown on the pokestop so that
+                // we keep moving and don't walk back and forth between 2 pokestops.
+                pokeStop.CooldownCompleteTimestampMs = DateTime.UtcNow.ToUnixTime() + 5 * 60 * 1000; // 5 minutes to cooldown for pokestop.
+            }
 
             if (++_stopsHit >= _storeRi) //TODO: OR item/pokemon bag is full //check stopsHit against storeRI random without dividing.
             {


### PR DESCRIPTION
## Short Description:
When we hit the pokestop limit, bot ends up walking back and forth between 2 pokestops.  This fixes the behavior of the bot so that it continues to walk more than 2 pokestops.

This is related to #215.  Now you can set 
```
"PokeStopLimit": 0,
```

and it will continue to walk and catch pokemon while skipping pokestops.

## Fixes (provide links to github issues if you can):
Fixes bug #215