### PR TITLE
Fix MSnipe don't work when use subpath parameter.

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/MSniperServiceTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/MSniperServiceTask.cs
@@ -410,7 +410,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             //return;//NEW SNIPE METHOD WILL BE ACTIVATED
 
-            var pth = Path.Combine(session.LogicSettings.ProfilePath, "SnipeMS.json");
+            var pth = Path.Combine(Directory.GetCurrentDirectory(), "SnipeMS.json");
             try
             {
                 if (!File.Exists(pth))


### PR DESCRIPTION
When use NecroBot with "subPath" parameter for multi bot and use MSniper to catch Pokemons.

1. MSniper write the "SnipeMS.json" file for NecroBot use to catch Pokemons in the current directory of Necrobot.
2. NecroBot check "SnipeMS.json" file to catch Pokemons from session.LogicSettings.ProfilePath (current directory + subPath).