### PR TITLE
Catching/Sniping pokemon not respecting DelayBetweenPokemonCatch setting.

### DIFF
--- a/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
@@ -60,6 +60,7 @@ namespace PoGo.NecroBot.Logic.Interfaces.Configuration
         double ForceExcellentThrowOverIv { get; }
         int ForceGreatThrowOverCp { get; }
         int ForceExcellentThrowOverCp { get; }
+        int DelayBetweenPokemonCatch { get; }
         int DelayBetweenPokemonUpgrade { get; }
         bool AutomaticallyLevelUpPokemon { get; }
         bool OnlyUpgradeFavorites { get; }

--- a/PoGo.NecroBot.Logic/Tasks/CatchNearbyPokemonsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchNearbyPokemonsTask.cs
@@ -109,7 +109,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                 // If pokemon is not last pokemon in list, create delay between catches, else keep moving.
                 if (!Equals(pokemons.ElementAtOrDefault(pokemons.Count() - 1), pokemon))
                 {
-                    await Task.Delay(session.LogicSettings.DelayBetweenPokemonUpgrade, cancellationToken);
+                    await Task.Delay(session.LogicSettings.DelayBetweenPokemonCatch, cancellationToken);
                 }
             }
         }

--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -584,7 +584,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                 }
 
                 if (!Equals(catchablePokemon.ElementAtOrDefault(catchablePokemon.Count - 1), pokemon))
-                    await Task.Delay(session.LogicSettings.DelayBetweenPokemonUpgrade, cancellationToken);
+                    await Task.Delay(session.LogicSettings.DelayBetweenPokemonCatch, cancellationToken);
             }
 
             if (!catchedPokemon)


### PR DESCRIPTION
## Short Description:
This reverts changes made in commit 9b2460c219fde1bc6f0da1b17c1a6ed47833d268, which changed `DelayBetweenPokemonCatch` to `DelayBetweenPokemonUpgrade` unintentionally.

The delay between pokemon catches and snipes was using the wrong delay value `DelayBetweenPokemonUpgrade` instead of `DelayBetweenPokemonCatch`.  This means that it would wait up to 10 seconds between catches/snipes if using the default upgrade delay.