### PR TITLE
Fixes bug #243 - Fix error while upgrading pokemon

### DIFF
--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -246,10 +246,17 @@ namespace PoGo.NecroBot.Logic
         public async Task<PokemonData> GetHighestPokemonOfTypeByCp(PokemonData pokemon)
         {
             var myPokemon = await GetPokemons();
-            var pokemons = myPokemon.ToList();
-            return pokemons.Where(x => x.PokemonId == pokemon.PokemonId)
-                .OrderByDescending(x => x.Cp)
-                .FirstOrDefault();
+            if (myPokemon != null)
+            {
+                var pokemons = myPokemon.ToList();
+                if (pokemons != null && 0 < pokemons.Count)
+                {
+                    return pokemons.Where(x => x.PokemonId == pokemon.PokemonId)
+                        .OrderByDescending(x => x.Cp)
+                        .FirstOrDefault();
+                }
+            }
+            return null;
         }
 
         public int GetStarDust()
@@ -266,10 +273,17 @@ namespace PoGo.NecroBot.Logic
         public async Task<PokemonData> GetHighestPokemonOfTypeByIv(PokemonData pokemon)
         {
             var myPokemon = await GetPokemons();
-            var pokemons = myPokemon.ToList();
-            return pokemons.Where(x => x.PokemonId == pokemon.PokemonId)
-                .OrderByDescending(PokemonInfo.CalculatePokemonPerfection)
-                .FirstOrDefault();
+            if (myPokemon != null)
+            {
+                var pokemons = myPokemon.ToList();
+                if (pokemons != null && 0 < pokemons.Count)
+                {
+                    return pokemons.Where(x => x.PokemonId == pokemon.PokemonId)
+                        .OrderByDescending(PokemonInfo.CalculatePokemonPerfection)
+                        .FirstOrDefault();
+                }
+            }
+            return null;
         }
 
         public async Task<IEnumerable<PokemonData>> GetHighestsCp(int limit)
@@ -586,6 +600,10 @@ namespace PoGo.NecroBot.Logic
         public async Task<UpgradePokemonResponse> UpgradePokemon(ulong pokemonid)
         {
             var upgradeResult = await _client.Inventory.UpgradePokemon(pokemonid);
+
+            // Immediately refresh inventory after upgrade.
+            await RefreshCachedInventory();
+
             return upgradeResult;
         }
     }

--- a/PoGo.NecroBot.Logic/PoGoUtils/PokemonInfo.cs
+++ b/PoGo.NecroBot.Logic/PoGoUtils/PokemonInfo.cs
@@ -81,6 +81,9 @@ namespace PoGo.NecroBot.Logic.PoGoUtils
 
         public static double CalculatePokemonPerfection(PokemonData poke)
         {
+            if (poke == null)
+                return 0;
+
             if (Math.Abs(poke.CpMultiplier + poke.AdditionalCpMultiplier) <= 0)
                 return (poke.IndividualAttack + poke.IndividualDefense + poke.IndividualStamina)/45.0*100.0;
 

--- a/PoGo.NecroBot.Logic/Tasks/LevelUpPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/LevelUpPokemonTask.cs
@@ -32,21 +32,24 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             var upgradeResult = await session.Inventory.UpgradePokemon(pokemon.Id);
 
-            var bestPokemonOfType = (session.LogicSettings.PrioritizeIvOverCp
-    ? await session.Inventory.GetHighestPokemonOfTypeByIv(upgradeResult.UpgradedPokemon)
-    : await session.Inventory.GetHighestPokemonOfTypeByCp(upgradeResult.UpgradedPokemon)) ?? upgradeResult.UpgradedPokemon;
-
-            if (upgradeResult.Result.ToString().ToLower().Contains("success"))
+            if (upgradeResult.UpgradedPokemon != null)
             {
-                session.EventDispatcher.Send(new UpgradePokemonEvent()
+                var bestPokemonOfType = (session.LogicSettings.PrioritizeIvOverCp
+                    ? await session.Inventory.GetHighestPokemonOfTypeByIv(upgradeResult.UpgradedPokemon)
+                    : await session.Inventory.GetHighestPokemonOfTypeByCp(upgradeResult.UpgradedPokemon)) ?? upgradeResult.UpgradedPokemon;
+
+                if (upgradeResult.Result.ToString().ToLower().Contains("success"))
                 {
-                    PokemonId = upgradeResult.UpgradedPokemon.PokemonId,
-                    Id = upgradeResult.UpgradedPokemon.Id,
-                    Cp = upgradeResult.UpgradedPokemon.Cp,
-                    BestCp = bestPokemonOfType.Cp,
-                    BestPerfection = PokemonInfo.CalculatePokemonPerfection(bestPokemonOfType),
-                    Perfection = PokemonInfo.CalculatePokemonPerfection(upgradeResult.UpgradedPokemon)
-                });
+                    session.EventDispatcher.Send(new UpgradePokemonEvent()
+                    {
+                        PokemonId = upgradeResult.UpgradedPokemon.PokemonId,
+                        Id = upgradeResult.UpgradedPokemon.Id,
+                        Cp = upgradeResult.UpgradedPokemon.Cp,
+                        BestCp = bestPokemonOfType.Cp,
+                        BestPerfection = PokemonInfo.CalculatePokemonPerfection(bestPokemonOfType),
+                        Perfection = PokemonInfo.CalculatePokemonPerfection(upgradeResult.UpgradedPokemon)
+                    });
+                }
             }
             return true;
 


### PR DESCRIPTION
## Short Description:
1. After upgrading pokemon, the cached inventory is not refreshed, which may result in stale data causing error.  Now we refresh cached inventory after each upgrade.
1. Added more error handling for null values.

## Fixes (provide links to github issues if you can):
Fixes #243 
