### PR TITLE
Re-enable manual kill switch

### DIFF
--- a/PoGo.NecroBot.CLI/BotDataSocketClient.cs
+++ b/PoGo.NecroBot.CLI/BotDataSocketClient.cs
@@ -168,7 +168,7 @@ namespace PoGo.NecroBot.CLI
                     session.EventDispatcher.Send(data);
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
             }
 

--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -92,10 +92,8 @@ namespace PoGo.NecroBot.CLI
 
             Logger.SetLogger(new ConsoleLogger(LogLevel.Service), _subPath);
 
-            // We can now rely on killswitch from checking the minimum client version returned by the API.
-            // A manually triggered killswitch is no longer needed.
-            //if (!_ignoreKillSwitch && CheckKillSwitch() || CheckMKillSwitch())
-                //return;
+            if (!_ignoreKillSwitch && CheckKillSwitch() || CheckMKillSwitch())
+                return;
 
             var profilePath = Path.Combine(Directory.GetCurrentDirectory(), _subPath);
             var profileConfigPath = Path.Combine(profilePath, "config");
@@ -379,10 +377,6 @@ namespace PoGo.NecroBot.CLI
 
         private static bool CheckKillSwitch()
         {
-            #if DEBUG
-                return false;
-            #endif
-
             using (var wC = new WebClient())
             {
                 try

--- a/PoGo.NecroBot.Logic/State/VersionCheckState.cs
+++ b/PoGo.NecroBot.Logic/State/VersionCheckState.cs
@@ -203,7 +203,7 @@ namespace PoGo.NecroBot.Logic.State
                 if (gitVersion > Assembly.GetExecutingAssembly().GetName().Version)
                     return false;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 return true; //better than just doing nothing when git server down
             }

--- a/PoGo.NecroBot.Logic/Tasks/MSniperServiceTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/MSniperServiceTask.cs
@@ -238,7 +238,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                     lastNotify = DateTime.Now;
                     //Logger.Write($"Connecting to MSniperService", LogLevel.Service);
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     TimeSpan ts = DateTime.Now - lastNotify;
                     if (ts.TotalMinutes > 5)


### PR DESCRIPTION
## Short Description:
We have now 2 types of kill switches:
1) Automatic kill switch - if Nia ever forces an update and our API emulation version becomes incompatible, then bot will automatically detect this and stop.
2) Manual kill switch - if we detect something that Nia is doing (i.e. captcha stuff) that may cause bans, we may enable manual kill switch to protect your accounts.