### PR TITLE
Fixes #298 - Don't skip pokemon by default.

### DIFF
--- a/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
@@ -282,13 +282,13 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public int KeepMinDuplicatePokemon = 1;
 
         /*NotCatch*/
-        [DefaultValue(true)]
+        [DefaultValue(false)]
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 55)]
-        public bool UsePokemonToNotCatchFilter = true;
+        public bool UsePokemonToNotCatchFilter = false;
 
-        [DefaultValue(true)]
+        [DefaultValue(false)]
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 56)]
-        public bool UsePokemonSniperFilterOnly = true;
+        public bool UsePokemonSniperFilterOnly = false;
 
         /*Dump Stats*/
         [DefaultValue(false)]

--- a/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
@@ -282,9 +282,9 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public int KeepMinDuplicatePokemon = 1;
 
         /*NotCatch*/
-        [DefaultValue(false)]
+        [DefaultValue(true)]
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 55)]
-        public bool UsePokemonToNotCatchFilter = false;
+        public bool UsePokemonToNotCatchFilter = true;
 
         [DefaultValue(false)]
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 56)]


### PR DESCRIPTION
## Short Description:

- Change default settings to allow pokemon to be sniped by default.
- By default set `UsePokemonToNotCatchFilter` to true, so that we don't snipe the regional pokemon by default (ban safety).

Recommended default config now is:
```
"PokemonsToIgnore": [
  "tauros",
  "mrmime",
  "kangaskhan",
  "farfetchd"
],
```
And
```
"UsePokemonToNotCatchFilter": true,
"UsePokemonSniperFilterOnly": false,
```
This allows all pokemon to be caught by default, except for the regional pokemon.  Advanced users can customize the snipe list and enable the snipe filter by setting `UsePokemonSniperFilterOnly` to true.

## Fixes (provide links to github issues if you can):
#298 
#299 
#302 
