### PR TITLE
Add retry when getInventory empty

### DIFF
--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -35,7 +35,7 @@ namespace PoGo.NecroBot.Logic
         private IEnumerable<PokemonSettings> _pokemonSettings;
 
         private readonly List<ItemId> _revives = new List<ItemId> { ItemId.ItemRevive, ItemId.ItemMaxRevive };
-        private GetInventoryResponse _cachedInventory;
+        private GetInventoryResponse _cachedInventory = null;
         private DateTime _lastRefresh;
 
         public Inventory(Client client, ILogicSettings logicSettings)
@@ -267,7 +267,11 @@ namespace PoGo.NecroBot.Logic
 
         public async void GetPlayerData()
         {
-            _player = await _client.Player.GetPlayer();
+            for (int i = 0; i < 3; i++)
+            {
+                _player = await _client.Player.GetPlayer();
+                if (_player != null) break;
+            }
         }
 
         public async Task<PokemonData> GetHighestPokemonOfTypeByIv(PokemonData pokemon)
@@ -587,8 +591,12 @@ namespace PoGo.NecroBot.Logic
             await ss.WaitAsync();
             try
             {
-                _lastRefresh = now;
-                _cachedInventory = await _client.Inventory.GetInventory();
+                for (int i = 0; i < 3; i++)
+                {
+                    _lastRefresh = now;
+                    _cachedInventory = await _client.Inventory.GetInventory();
+                    if (_cachedInventory != null && _cachedInventory.InventoryDelta.InventoryItems.Count > 0) break;
+                }
                 return _cachedInventory;
             }
             finally

--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -31,8 +31,8 @@ namespace PoGo.NecroBot.Logic
         private readonly ILogicSettings _logicSettings;
         private GetPlayerResponse _player = null;
         private int _level = 0;
-        private DownloadItemTemplatesResponse _templates;
-        private IEnumerable<PokemonSettings> _pokemonSettings;
+        private DownloadItemTemplatesResponse _templates = null;
+        private IEnumerable<PokemonSettings> _pokemonSettings = null;
 
         private readonly List<ItemId> _revives = new List<ItemId> { ItemId.ItemRevive, ItemId.ItemMaxRevive };
         private GetInventoryResponse _cachedInventory = null;
@@ -450,10 +450,24 @@ namespace PoGo.NecroBot.Logic
 
         public async Task<IEnumerable<PokemonSettings>> GetPokemonSettings()
         {
-            if (_templates == null || _pokemonSettings == null)
+            var ss = new SemaphoreSlim(1);
+
+            await ss.WaitAsync();
+            try
             {
-                _templates = await _client.Download.GetItemTemplates();
-                _pokemonSettings = _templates.ItemTemplates.Select(i => i.PokemonSettings).Where(p => p != null && p.FamilyId != PokemonFamilyId.FamilyUnset);
+                if (_templates == null || _pokemonSettings == null)
+                {
+                    for (int j = 0; j < 3; j++)
+                    {
+                        _templates = await _client.Download.GetItemTemplates();
+                        _pokemonSettings = _templates.ItemTemplates.Select(i => i.PokemonSettings).Where(p => p != null && p.FamilyId != PokemonFamilyId.FamilyUnset);
+                        if (_templates.ItemTemplates.Count > 10) break;
+                    }
+                }
+            }
+            finally
+            {
+                ss.Release();
             }
 
             return _pokemonSettings;


### PR DESCRIPTION
When program start, it often get empty inventory information. Add retry to reget it.
It also add protection and retry in get pokemon settings to prevent crash.