### PR TITLE
Re-work pokestop and pokemon limits to store session stats in LiteDB

### DIFF
--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -265,9 +265,7 @@ namespace PoGo.NecroBot.CLI
             _session.Navigation.WalkStrategy.UpdatePositionEvent +=
                 (lat, lng) => _session.EventDispatcher.Send(new UpdatePositionEvent { Latitude = lat, Longitude = lng });
             _session.Navigation.WalkStrategy.UpdatePositionEvent += SaveLocationToDisk;
-            UseNearbyPokestopsTask.UpdateTimeStampsPokestop += SaveTimeStampsPokestopToDisk;
-            CatchPokemonTask.UpdateTimeStampsPokemon += SaveTimeStampsPokemonToDisk;
-
+            
             ProgressBar.Fill(100);
 
             machine.AsyncStart(new VersionCheckState(), _session, _subPath);
@@ -311,30 +309,7 @@ namespace PoGo.NecroBot.CLI
             var coordsPath = Path.Combine(_session.LogicSettings.ProfileConfigPath, "LastPos.ini");
             File.WriteAllText(coordsPath, $"{lat}:{lng}");
         }
-
-        private static void SaveTimeStampsPokestopToDisk()
-        {
-            if (_session == null) return;
-
-            var path = Path.Combine(_session.LogicSettings.ProfileConfigPath, "PokestopTS.txt");
-            var fileContent = _session.Stats.PokeStopTimestamps.Select(t => t.ToString()).ToList();
-
-            if (fileContent.Count > 0)
-                File.WriteAllLines(path, fileContent.ToArray());
-        }
-
-        private static void SaveTimeStampsPokemonToDisk()
-        {
-            if (_session == null) return;
-
-            var path = Path.Combine(_session.LogicSettings.ProfileConfigPath, "PokemonTS.txt");
-
-            var fileContent = _session.Stats.PokemonTimestamps.Select(t => t.ToString()).ToList();
-
-            if (fileContent.Count > 0)
-                File.WriteAllLines(path, fileContent.ToArray());
-        }
-
+        
         private static bool CheckMKillSwitch()
         {
             using (var wC = new WebClient())

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -69,6 +69,10 @@
       <HintPath>$(SolutionDir)\packages\Google.Protobuf.3.1.0\lib\net45\Google.Protobuf.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="LiteDB, Version=2.0.4.0, Culture=neutral, PublicKeyToken=4ee40123013c9f27, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\LiteDB.2.0.4\lib\net35\LiteDB.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="LRUCache, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\LRUCache.0.1.0\lib\Net20\LRUCache.dll</HintPath>
       <Private>True</Private>

--- a/PoGo.NecroBot.Logic/Service/TelegramService.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramService.cs
@@ -316,14 +316,14 @@ namespace PoGo.NecroBot.Logic.Service
                     if (_session.LogicSettings.UseCatchLimit)
                     {
                         answerTextmessage += String.Format("\nCATCH LIMIT: {0}/{1}",
-                                    _session.Stats.PokemonTimestamps.Count,
+                                    _session.Stats.GetNumPokemonsInLast24Hours(),
                                     _session.LogicSettings.CatchPokemonLimit);
                     }
 
                     if (_session.LogicSettings.UsePokeStopLimit)
                     {
                         answerTextmessage += String.Format("\nPOKESTOP LIMIT: {0}/{1}",
-                                    _session.Stats.PokeStopTimestamps.Count,
+                                    _session.Stats.GetNumPokestopsInLast24Hours(),
                                     _session.LogicSettings.PokeStopLimit);
                     }
 

--- a/PoGo.NecroBot.Logic/State/LoadSaveState.cs
+++ b/PoGo.NecroBot.Logic/State/LoadSaveState.cs
@@ -85,65 +85,7 @@ namespace PoGo.NecroBot.Logic.State
                     });
                 }
             }
-
-            List<Int64> list = new List<Int64>();
-            // for pokestops
-            try
-            {
-                var path = Path.Combine(session.LogicSettings.ProfileConfigPath, "PokestopTS.txt");
-                if (File.Exists(path))
-                {
-                    var content = File.ReadLines(path);
-                    foreach (var c in content)
-                    {
-                        if (c.Length > 0)
-                        {
-                            list.Add(Convert.ToInt64(c));
-                        }
-                    }
-                }
-            }
-            catch (Exception)
-            {
-                session.EventDispatcher.Send(new ErrorEvent
-                {
-                    Message = "Garbage information in PokestopTS.txt"
-                });
-            }
-            foreach (var l in list)
-            {
-                session.Stats.PokeStopTimestamps.Add(l);
-            }
-
-            // for pokemons
-            list = new List<Int64>();
-            try
-            {
-                var path = Path.Combine(session.LogicSettings.ProfileConfigPath, "PokemonTS.txt");
-                if (File.Exists(path))
-                {
-                    var content = File.ReadLines(path);
-                    foreach (var c in content)
-                    {
-                        if (c.Length > 0)
-                        {
-                            list.Add(Convert.ToInt64(c));
-                        }
-                    }
-                }
-            }
-            catch (Exception)
-            {
-                session.EventDispatcher.Send(new ErrorEvent
-                {
-                    Message = "Garbage information in PokemonTS.txt"
-                });
-            }
-            foreach (var l in list)
-            {
-                session.Stats.PokemonTimestamps.Add(l);
-            }
-
+            
             await Task.Delay(3000, cancellationToken);
             return new InfoState();
         }

--- a/PoGo.NecroBot.Logic/State/Session.cs
+++ b/PoGo.NecroBot.Logic/State/Session.cs
@@ -64,7 +64,7 @@ namespace PoGo.NecroBot.Logic.State
 
             Translation = translation;
             Reset(settings, LogicSettings);
-            Stats = new SessionStats();
+            Stats = new SessionStats(this);
         }
         public List<FortData> Forts { get; set; }
         public List<FortData> VisibleForts { get; set; }

--- a/PoGo.NecroBot.Logic/State/SessionStats.cs
+++ b/PoGo.NecroBot.Logic/State/SessionStats.cs
@@ -1,22 +1,154 @@
-﻿using System;
+﻿using LiteDB;
+using PoGo.NecroBot.Logic.Event;
+using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.IO;
 
 namespace PoGo.NecroBot.Logic.State
 {
     public class SessionStats
     {
+        const string DB_NAME = @"SessionStats.db";
+        const string POKESTOP_STATS_COLLECTION = "PokeStopTimestamps";
+        const string POKEMON_STATS_COLLECTION  = "PokemonTimestamps";
+
         public int SnipeCount { get; set; }
         public DateTime LastSnipeTime { get; set; }
-        public List<Int64> PokeStopTimestamps { get; private set; }
-        public List<Int64> PokemonTimestamps { get; private set; }
+        public DateTime StartTime { get; set; }
+        
+        private LiteDatabase db;
+        private LiteCollection<PokeStopTimestamp> pokestopTimestampCollection;
+        private LiteCollection<PokemonTimestamp> pokemonTimestampCollection;
 
-        public SessionStats()
+        class PokeStopTimestamp
         {
-            PokemonTimestamps = new List<Int64>();
-            PokeStopTimestamps = new List<Int64>();
+            public Int64 Timestamp { get; set; }
+        }
+
+        class PokemonTimestamp
+        {
+            public Int64 Timestamp { get; set; }
+        }
+
+        public SessionStats(ISession session)
+        {
+            StartTime = DateTime.Now;
+
+            InitializeDatabase(session);
+            LoadLegacyData(session);
+        }
+
+        public void InitializeDatabase(ISession session)
+        {
+            var path = Path.Combine(session.LogicSettings.ProfileConfigPath, DB_NAME);
+            db = new LiteDatabase(path);
+            pokestopTimestampCollection = db.GetCollection<PokeStopTimestamp>(POKESTOP_STATS_COLLECTION);
+            pokemonTimestampCollection = db.GetCollection<PokemonTimestamp>(POKEMON_STATS_COLLECTION);
+
+            // Add index
+            pokestopTimestampCollection.EnsureIndex(s => s.Timestamp);
+            pokemonTimestampCollection.EnsureIndex(s => s.Timestamp);
+        }
+
+        public void AddPokestopTimestamp(Int64 ts)
+        {
+            if (!pokestopTimestampCollection.Exists(s => s.Timestamp == ts))
+            {
+                var stat = new PokeStopTimestamp { Timestamp = ts };
+                pokestopTimestampCollection.Insert(stat);
+            }
+        }
+
+        public void AddPokemonTimestamp(Int64 ts)
+        {
+            if (!pokemonTimestampCollection.Exists(s => s.Timestamp == ts))
+            {
+                var stat = new PokemonTimestamp { Timestamp = ts };
+                pokemonTimestampCollection.Insert(stat);
+            }
+        }
+
+        public void CleanOutExpiredStats()
+        {
+            var TSminus24h = DateTime.Now.AddHours(-24).Ticks;
+            pokestopTimestampCollection.Delete(s => s.Timestamp < TSminus24h);
+            pokemonTimestampCollection.Delete(s => s.Timestamp < TSminus24h);
+        }
+
+        public int GetNumPokestopsInLast24Hours()
+        {
+            var TSminus24h = DateTime.Now.AddHours(-24).Ticks;
+            return pokestopTimestampCollection.Count(s => s.Timestamp >= TSminus24h);
+        }
+
+        public int GetNumPokemonsInLast24Hours()
+        {
+            var TSminus24h = DateTime.Now.AddHours(-24).Ticks;
+            return pokemonTimestampCollection.Count(s => s.Timestamp >= TSminus24h);
+        }
+
+        public void LoadLegacyData(ISession session)
+        {
+            List<Int64> list = new List<Int64>();
+            // for pokestops
+            try
+            {
+                var path = Path.Combine(session.LogicSettings.ProfileConfigPath, "PokestopTS.txt");
+                if (File.Exists(path))
+                {
+                    var content = File.ReadLines(path);
+                    foreach (var c in content)
+                    {
+                        if (c.Length > 0)
+                        {
+                            list.Add(Convert.ToInt64(c));
+                        }
+                    }
+                    File.Delete(path);
+                }
+            }
+            catch (Exception)
+            {
+                session.EventDispatcher.Send(new ErrorEvent
+                {
+                    Message = "Garbage information in PokestopTS.txt"
+                });
+            }
+
+            foreach (var l in list)
+            {
+                AddPokestopTimestamp(l);
+            }
+
+            // for pokemons
+            list = new List<Int64>();
+            try
+            {
+                var path = Path.Combine(session.LogicSettings.ProfileConfigPath, "PokemonTS.txt");
+                if (File.Exists(path))
+                {
+                    var content = File.ReadLines(path);
+                    foreach (var c in content)
+                    {
+                        if (c.Length > 0)
+                        {
+                            list.Add(Convert.ToInt64(c));
+                        }
+                    }
+                    File.Delete(path);
+                }
+            }
+            catch (Exception)
+            {
+                session.EventDispatcher.Send(new ErrorEvent
+                {
+                    Message = "Garbage information in PokemonTS.txt"
+                });
+            }
+            foreach (var l in list)
+            {
+                AddPokemonTimestamp(l);
+            }
         }
     }
 }

--- a/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
@@ -22,8 +22,6 @@ using PoGo.NecroBot.Logic.Model;
 
 namespace PoGo.NecroBot.Logic.Tasks
 {
-    public delegate void UpdateTimeStampsPokestopDelegate();
-
     public class UseNearbyPokestopsTask
     {
         private static int _stopsHit;
@@ -34,8 +32,6 @@ namespace PoGo.NecroBot.Logic.Tasks
         private static List<FortData> _pokestopList;
         public static bool _pokestopLimitReached;
         public static bool _pokestopTimerReached;
-
-        public static event UpdateTimeStampsPokestopDelegate UpdateTimeStampsPokestop;
 
         internal static void Initialize()
         {
@@ -54,29 +50,18 @@ namespace PoGo.NecroBot.Logic.Tasks
             if (!session.LogicSettings.UsePokeStopLimit) return false;
             if (_pokestopLimitReached || _pokestopTimerReached) return true;
 
-            // Check if user defined max Pokestops reached
-            if (!session.Stats.PokeStopTimestamps.Any()) return false;
-            var timeDiff = (DateTime.Now - new DateTime(session.Stats.PokeStopTimestamps.First()));
+            session.Stats.CleanOutExpiredStats();
 
-            if (session.Stats.PokeStopTimestamps.Count >= session.LogicSettings.PokeStopLimit)
+            // Check if user defined max Pokestops reached
+            var timeDiff = (DateTime.Now - session.Stats.StartTime);
+
+            if (session.Stats.GetNumPokestopsInLast24Hours() >= session.LogicSettings.PokeStopLimit)
             {
                 session.EventDispatcher.Send(new ErrorEvent
                 {
                     Message = session.Translation.GetTranslation(TranslationString.PokestopLimitReached)
                 });
-
-                // Check Timestamps & delete older than 24h
-                var TSminus24h = DateTime.Now.AddHours(-24).Ticks;
-                for (int i = 0; i < session.Stats.PokeStopTimestamps.Count; i++)
-                {
-                    if (session.Stats.PokeStopTimestamps[i] < TSminus24h)
-                    {
-                        Logger.Write($"Removing stored Pokestop timestamp {session.Stats.PokeStopTimestamps[i]}", LogLevel.Info);
-                        session.Stats.PokeStopTimestamps.Remove(session.Stats.PokeStopTimestamps[i]);
-                    }
-                }
-
-                UpdateTimeStampsPokestop?.Invoke();
+                
                 _pokestopLimitReached = true;
                 return true;
             }
@@ -88,18 +73,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                 {
                     Message = session.Translation.GetTranslation(TranslationString.PokestopTimerReached)
                 });
-
-                // Check Timestamps & delete older than 24h
-                var TSminus24h = DateTime.Now.AddHours(-24).Ticks;
-                for (int i = 0; i < session.Stats.PokeStopTimestamps.Count; i++)
-                {
-                    if (session.Stats.PokeStopTimestamps[i] < TSminus24h)
-                    {
-                        session.Stats.PokeStopTimestamps.Remove(session.Stats.PokeStopTimestamps[i]);
-                    }
-                }
-
-                UpdateTimeStampsPokestop?.Invoke();
+                
                 _pokestopTimerReached = true;
                 return true;
             }
@@ -428,9 +402,8 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                     if (session.LogicSettings.UsePokeStopLimit)
                     {
-                        session.Stats.PokeStopTimestamps.Add(DateTime.Now.Ticks);
-                        UpdateTimeStampsPokestop?.Invoke();
-                        Logger.Write($"(POKESTOP LIMIT) {session.Stats.PokeStopTimestamps.Count}/{session.LogicSettings.PokeStopLimit}",
+                        session.Stats.AddPokestopTimestamp(DateTime.Now.Ticks);
+                        Logger.Write($"(POKESTOP LIMIT) {session.Stats.GetNumPokestopsInLast24Hours()}/{session.LogicSettings.PokeStopLimit}",
                             LogLevel.Info, ConsoleColor.Yellow);
                     }
                     break; //Continue with program as loot was succesfull.

--- a/PoGo.NecroBot.Logic/app.config
+++ b/PoGo.NecroBot.Logic/app.config
@@ -50,6 +50,14 @@
         <assemblyIdentity name="Microsoft.Win32.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Core" publicKeyToken="b77a5c561934e089" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System" publicKeyToken="b77a5c561934e089" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" /></startup></configuration>

--- a/PoGo.NecroBot.Logic/packages.config
+++ b/PoGo.NecroBot.Logic/packages.config
@@ -5,6 +5,7 @@
   <package id="EngineIoClientDotNet" version="0.9.22" targetFramework="net452" />
   <package id="GeoCoordinate" version="1.1.0" targetFramework="net452" />
   <package id="Google.Protobuf" version="3.1.0" targetFramework="net452" />
+  <package id="LiteDB" version="2.0.4" targetFramework="net452" />
   <package id="LRUCache" version="0.1.0" targetFramework="net452" />
   <package id="Microsoft.AspNet.SignalR.Client" version="2.2.1" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />


### PR DESCRIPTION
## Short Description:
Fixes the pokestop/pokemon limit bug which occurs when a relog happens - the pokestop/pokemon limits are saved twice.

- We are now storing all session stats in an embedded database called LiteDB.  
- The session stats are in a file called SessionStats.db. PokemonTS.txt and PokestopTS.txt data will be imported into the database and then deleted.
- The database is self-cleaning. It will automatically clean out data that is older than 24 hours.

## Fixes (provide links to github issues if you can):

Fixes #336 