### PR TITLE
Fix the update mechanism to properly upgrade old config file.

### DIFF
--- a/PoGo.NecroBot.Logic/Model/Settings/GlobalSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/GlobalSettings.cs
@@ -220,6 +220,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
             var profilePath = Path.Combine(Directory.GetCurrentDirectory(), path);
             var profileConfigPath = Path.Combine(profilePath, "config");
             var configFile = Path.Combine(profileConfigPath, "config.json");
+            var schemaFile = Path.Combine(profileConfigPath, "config.schema.json");
             var shouldExit = false;
 
             if (File.Exists(configFile))
@@ -261,8 +262,12 @@ namespace PoGo.NecroBot.Logic.Model.Settings
                         // validate Json using JsonSchema
                         if (validate)
                         {
+                            JObject jsonObj = JObject.Parse(input);
+
+                            // Migrate before validation.
+                            MigrateSettings(jsonObj, configFile, schemaFile);
+
                             Logger.Write("Validating config.json...");
-                            var jsonObj = JObject.Parse(input);
                             IList<ValidationError> errors = null;
                             bool valid;
                             try
@@ -353,6 +358,50 @@ namespace PoGo.NecroBot.Logic.Model.Settings
             }
 
             return shouldExit ? null : settings;
+        }
+
+        private static void MigrateSettings(JObject settings, string configFile, string schemaFile)
+        {
+            if (settings["UpdateConfig"]?["SchemaVersion"] == null)
+            {
+                // The is the first time setup for old config.json files without the SchemaVersion.
+                // Just set this to 0 so that we can handle the upgrade in case 0.
+                settings["UpdateConfig"]["SchemaVersion"] = 0;
+            }
+
+            int schemaVersion = (int)settings["UpdateConfig"]["SchemaVersion"];
+            if (schemaVersion == UpdateConfig.CURRENT_SCHEMA_VERSION)
+            {
+                Logger.Write("Configuration is up-to-date. Schema version: " + schemaVersion);
+                return;
+            }
+
+            // Backup old config file.
+            string backupPath = configFile.Replace(".json", $"-{schemaVersion}.backup.json");
+            Logger.Write($"Backing up config.json to: {backupPath}", LogLevel.Info);
+            File.Copy(configFile, backupPath);
+
+            // Add future schema migrations below.
+            int version;
+            for (version = schemaVersion; version < UpdateConfig.CURRENT_SCHEMA_VERSION; version++)
+            {
+                Logger.Write($"Migrating configuration from schema version {version} to {version + 1}", LogLevel.Info);
+                switch(version)
+                {
+                    case 0:
+                        settings["UpdateConfig"]["SchemaVersion"] = UpdateConfig.CURRENT_SCHEMA_VERSION;
+                        break;
+                    case 1:
+                        // TODO Add schema migrations from version 1 to 2 here.
+                        break;
+
+                    case 2:
+                        // TODO Add schema migrations from version 2 to 3 here.
+                        break;
+
+                    // Add more here.
+                }
+            }
         }
 
         public void CheckProxy(ITranslation translator)

--- a/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
@@ -24,6 +24,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public string ProfilePath => _settings.ProfilePath;
         public string ProfileConfigPath => _settings.ProfileConfigPath;
         public string GeneralConfigPath => _settings.GeneralConfigPath;
+        public int SchemaVersion => _settings.UpdateConfig.SchemaVersion;
         public bool CheckForUpdates => _settings.UpdateConfig.CheckForUpdates;
         public bool AutoUpdate => _settings.UpdateConfig.AutoUpdate;
         public bool TransferConfigAndAuthOnUpdate => _settings.UpdateConfig.TransferConfigAndAuthOnUpdate;

--- a/PoGo.NecroBot.Logic/Model/Settings/UpdateConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/UpdateConfig.cs
@@ -6,16 +6,22 @@ namespace PoGo.NecroBot.Logic.Model.Settings
     [JsonObject(Title = "Update Config", Description = "Set your update settings.", ItemRequired = Required.DisallowNull)]
     public class UpdateConfig
     {
-        [DefaultValue(true)]
+        public const int CURRENT_SCHEMA_VERSION = 1;
+
+        [DefaultValue(CURRENT_SCHEMA_VERSION)]
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 1)]
-        public bool CheckForUpdates = true;
+        public int SchemaVersion = CURRENT_SCHEMA_VERSION;
 
         [DefaultValue(true)]
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 2)]
-        public bool AutoUpdate = true;
+        public bool CheckForUpdates = true;
 
         [DefaultValue(true)]
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 3)]
+        public bool AutoUpdate = true;
+
+        [DefaultValue(true)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 4)]
         public bool TransferConfigAndAuthOnUpdate = true;
     }
 }


### PR DESCRIPTION
## Short Description:
Re-designed the configuration update mechanism to properly upgrade config file.

1. Config files now have a schema version associated with them, which is used to determine when an upgrade of the config is needed.
2. Before an update occurs, the old config.json is backed up to `config-<old version>.backup.json`, so you should never lose your old settings, and you can compare the old and the new.
3. Updates to your configuration file now happen whenever you start up the bot.  The bot will check to see if your configuration is outdated and will upgrade properly.
4. The update mechanism is able to handle upgrades for multiple versions.  For example, if you are using schema version 1 and the newest version is 8, then the update mechanism will upgrade from 1->2, 2->3, 3->4, etc. until the config file is version 8.

## Fixes (provide links to github issues if you can):
Fixes #332
