### PR TITLE
Fix in RenamePokemonTask - removed unnecessary delay from the cases w…

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/RenamePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RenamePokemonTask.cs
@@ -54,9 +54,10 @@ namespace PoGo.NecroBot.Logic.Tasks
                             session.Translation.GetTranslation(TranslationString.PokemonRename, session.Translation.GetPokemonTranslation(pokemon.PokemonId),
                                 pokemon.Id, oldNickname, newNickname)
                     });
-                }
 
-                DelayingUtils.Delay(session.LogicSettings.RenamePokemonActionDelay, 500);
+                    //Delay only if the pokemon was really renamed!
+                    DelayingUtils.Delay(session.LogicSettings.RenamePokemonActionDelay, 500);
+                }
             }
         }
     }


### PR DESCRIPTION
Rename pokemon task scans the whole pokemon inventory and tries to rename every found pokemon according to the configured options.
At the end of this task there was a delay which was however applied also in cases the API request was not executed (no renaming).