### PR TITLE
Bug fix - Load location before logging in.

### DIFF
--- a/PoGo.NecroBot.Logic/State/LoadSaveState.cs
+++ b/PoGo.NecroBot.Logic/State/LoadSaveState.cs
@@ -87,7 +87,7 @@ namespace PoGo.NecroBot.Logic.State
             }
             
             await Task.Delay(3000, cancellationToken);
-            return new CheckTosState();
+            return new LoginState();
         }
 
         private static Tuple<double, double> LoadPositionFromDisk(ISession session)

--- a/PoGo.NecroBot.Logic/State/LoginState.cs
+++ b/PoGo.NecroBot.Logic/State/LoginState.cs
@@ -175,7 +175,7 @@ namespace PoGo.NecroBot.Logic.State
             {
                 return new BotSwitcherState(this.pokemonToCatch);
             }
-            return new LoadSaveState();
+            return new CheckTosState();
         }
 
         private async Task LogLoginHistory(ISession session, CancellationToken cancellationToken)

--- a/PoGo.NecroBot.Logic/State/VersionCheckState.cs
+++ b/PoGo.NecroBot.Logic/State/VersionCheckState.cs
@@ -44,7 +44,7 @@ namespace PoGo.NecroBot.Logic.State
                     Message = session.Translation.GetTranslation( TranslationString.CheckForUpdatesDisabled, Assembly.GetExecutingAssembly().GetName().Version.ToString( 3 ) )
                 } );
 
-                return new LoginState();
+                return new LoadSaveState();
             }
 
             var autoUpdate = session.LogicSettings.AutoUpdate;
@@ -56,7 +56,7 @@ namespace PoGo.NecroBot.Logic.State
                     Message =
                         session.Translation.GetTranslation(TranslationString.GotUpToDateVersion, Assembly.GetExecutingAssembly().GetName().Version.ToString(4))
                 });
-                return new LoginState();
+                return new LoadSaveState();
             }
             if ( !autoUpdate )
             {
@@ -74,7 +74,7 @@ namespace PoGo.NecroBot.Logic.State
                             break;
                         case "n":
                             Logger.Write( "Update Skipped", LogLevel.Update );
-                            return new LoginState();
+                            return new LoadSaveState();
                         default:
                             Logger.Write( session.Translation.GetTranslation( TranslationString.PromptError, "Y", "N" ), LogLevel.Error );
                             continue;
@@ -98,7 +98,7 @@ namespace PoGo.NecroBot.Logic.State
             Logger.Write(downloadLink, LogLevel.Info);
 
             if (!DownloadFile(downloadLink, downloadFilePath))
-                return new LoginState();
+                return new LoadSaveState();
 
             session.EventDispatcher.Send(new UpdateEvent
             {
@@ -106,7 +106,7 @@ namespace PoGo.NecroBot.Logic.State
             });
 
             if (!UnpackFile(downloadFilePath, extractedDir))
-                return new LoginState();
+                return new LoadSaveState();
 
             session.EventDispatcher.Send(new UpdateEvent
             {
@@ -114,7 +114,7 @@ namespace PoGo.NecroBot.Logic.State
             });
 
             if (!MoveAllFiles(extractedDir, destinationDir))
-                return new LoginState();
+                return new LoadSaveState();
 
             session.EventDispatcher.Send(new UpdateEvent
             {


### PR DESCRIPTION
## Short Description:
Previously, we logged in first and then loaded the last position and then updated the position of the bot.  So there is a potential softban after login if your default position and last position are far away from each other.

Now the last position is loaded before logging in, which should decrease softban on startup.