### PR TITLE
Evolved If Set Below Total Of Current Pokemon

### DIFF
--- a/EvolvePokemonTask.cs
+++ b/EvolvePokemonTask.cs
@@ -1,0 +1,194 @@
+﻿#region using directives
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using PoGo.NecroBot.Logic.Common;
+using PoGo.NecroBot.Logic.Event;
+using PoGo.NecroBot.Logic.State;
+using PoGo.NecroBot.Logic.Utils;
+using POGOProtos.Data;
+using POGOProtos.Inventory.Item;
+
+#endregion
+
+namespace PoGo.NecroBot.Logic.Tasks
+{
+    public class EvolvePokemonTask
+    {
+        private static DateTime _lastLuckyEggTime;
+
+        public static async Task Execute(ISession session, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            //await session.Inventory.RefreshCachedInventory();
+
+            var pokemonToEvolveTask = await session.Inventory.GetPokemonToEvolve(session.LogicSettings.PokemonsToEvolve);
+            var pokemonToEvolve = pokemonToEvolveTask.Where(p => p != null).ToList();
+
+            session.EventDispatcher.Send(new EvolveCountEvent
+            {
+                Evolves = pokemonToEvolve.Count()
+            });
+
+            if (pokemonToEvolve.Any())
+            {
+                if (session.LogicSettings.KeepPokemonsThatCanEvolve)
+                {
+                    var luckyEggMin = session.LogicSettings.UseLuckyEggsMinPokemonAmount;
+                    var maxStorage = session.Profile.PlayerData.MaxPokemonStorage;
+                    var totalPokemon = await session.Inventory.GetPokemons();
+                    var totalEggs = await session.Inventory.GetEggs();
+
+                    var pokemonNeededInInventory = (maxStorage - totalEggs.Count()) * session.LogicSettings.EvolveKeptPokemonsAtStorageUsagePercentage / 100.0f;
+                    var needPokemonToStartEvolve = Math.Round(
+                        Math.Max(0, Math.Min(session.LogicSettings.EvolveKeptPokemonIfBagHasOverThisManyPokemon,
+                            Math.Min(pokemonNeededInInventory, session.Profile.PlayerData.MaxPokemonStorage))));
+
+                    var deltaCount = needPokemonToStartEvolve - totalPokemon.Count();
+                    if (session.LogicSettings.UseLuckyEggsWhileEvolving)
+                    {
+                        if (luckyEggMin > maxStorage)
+                        {
+                            session.EventDispatcher.Send(new WarnEvent
+                            {
+                                Message = session.Translation.GetTranslation(TranslationString.UseLuckyEggsMinPokemonAmountTooHigh,
+                                luckyEggMin, maxStorage)
+                            });
+                            return;
+                        }
+                    }
+
+                    if (deltaCount > 0)
+                    {
+                        session.EventDispatcher.Send(new UpdateEvent()
+                        {
+                            Message = session.Translation.GetTranslation(TranslationString.WaitingForMorePokemonToEvolve,
+                                pokemonToEvolve.Count, deltaCount, totalPokemon.Count(), needPokemonToStartEvolve, session.LogicSettings.EvolveKeptPokemonsAtStorageUsagePercentage)
+                        });
+                        return;
+                    }
+                    else
+                    {
+                        if (await shouldUseLuckyEgg(session, pokemonToEvolve))
+                        {
+                            await UseLuckyEgg(session);
+                        }
+                        await Evolve(session, pokemonToEvolve);
+                    }
+                }
+                else if (session.LogicSettings.EvolveAllPokemonWithEnoughCandy || session.LogicSettings.EvolveAllPokemonAboveIv)
+                {
+                    if (await shouldUseLuckyEgg(session, pokemonToEvolve))
+                    {
+                        await UseLuckyEgg(session);
+                    }
+                    await Evolve(session, pokemonToEvolve);
+                }
+            }
+        }
+
+        public static async Task UseLuckyEgg(ISession session)
+        {
+            //await session.Inventory.RefreshCachedInventory();
+
+            var inventoryContent = await session.Inventory.GetItems();
+
+            var luckyEggs = inventoryContent.Where(p => p.ItemId == ItemId.ItemLuckyEgg);
+            var luckyEgg = luckyEggs.FirstOrDefault();
+
+            if (_lastLuckyEggTime.AddMinutes(30).Ticks > DateTime.Now.Ticks)
+                return;
+
+            _lastLuckyEggTime = DateTime.Now;
+            await session.Client.Inventory.UseItemXpBoost();
+            if (luckyEgg != null) session.EventDispatcher.Send(new UseLuckyEggEvent { Count = luckyEgg.Count - 1 });
+            DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 0);
+        }
+
+        private static async Task Evolve(ISession session, List<PokemonData> pokemonToEvolve)
+        {
+            var pokemonSettings = await session.Inventory.GetPokemonSettings();
+            var pokemonFamilies = await session.Inventory.GetPokemonFamilies();
+
+            int sequence = 1;
+            foreach (var pokemon in pokemonToEvolve)
+            {
+                var setting =
+                pokemonSettings.FirstOrDefault(q => pokemon != null && q.PokemonId == pokemon.PokemonId);
+                var family = pokemonFamilies.FirstOrDefault(q => setting != null && q.FamilyId == setting.FamilyId);
+
+                if (family.Candy_ < setting.CandyToEvolve) continue;
+                // no cancellationToken.ThrowIfCancellationRequested here, otherwise the lucky egg would be wasted.
+                var evolveResponse = await session.Client.Inventory.EvolvePokemon(pokemon.Id);
+                if (evolveResponse.Result == POGOProtos.Networking.Responses.EvolvePokemonResponse.Types.Result.Success)
+                {
+                    family.Candy_ += -setting.CandyToEvolve;
+                    await session.Inventory.UpdateCandy(family, -setting.CandyToEvolve);
+                    await session.Inventory.DeletePokemonFromInvById(pokemon.Id);
+                    await session.Inventory.AddPokemonToCache(evolveResponse.EvolvedPokemonData);
+                }
+
+                session.EventDispatcher.Send(new PokemonEvolveEvent
+                {
+                    Id = pokemon.PokemonId,
+                    Exp = evolveResponse.ExperienceAwarded,
+                    UniqueId = pokemon.Id,
+                    Result = evolveResponse.Result,
+                    Sequence = pokemonToEvolve.Count() ==1?0:sequence++
+                });
+
+                if (!pokemonToEvolve.Last().Equals(pokemon))
+                    DelayingUtils.Delay(session.LogicSettings.EvolveActionDelay, 0);
+            }
+        }
+
+        private static async Task<Boolean> shouldUseLuckyEgg(ISession session, List<PokemonData> pokemonToEvolve)
+        {
+            var inventoryContent = await session.Inventory.GetItems();
+
+            var luckyEggs = inventoryContent.Where(p => p.ItemId == ItemId.ItemLuckyEgg);
+            var luckyEgg = luckyEggs.FirstOrDefault();
+
+            if (session.LogicSettings.UseLuckyEggsWhileEvolving && luckyEgg != null && luckyEgg.Count > 0)
+            {
+                if (pokemonToEvolve.Count >= session.LogicSettings.UseLuckyEggsMinPokemonAmount)
+                {
+                    return true;
+                }
+                else
+                {
+                    var evolvablePokemon = await session.Inventory.GetPokemons();
+
+                    var deltaPokemonToUseLuckyEgg = session.LogicSettings.UseLuckyEggsMinPokemonAmount -
+                                                               pokemonToEvolve.Count;
+
+                    var availableSpace = session.Profile.PlayerData.MaxPokemonStorage - evolvablePokemon.Count();
+
+                    if (deltaPokemonToUseLuckyEgg > availableSpace)
+                    {
+                        var possibleLimitInThisIteration = pokemonToEvolve.Count + availableSpace;
+
+                        session.EventDispatcher.Send(new NoticeEvent()
+                        {
+                            Message = session.Translation.GetTranslation(TranslationString.UseLuckyEggsMinPokemonAmountTooHigh,
+                                session.LogicSettings.UseLuckyEggsMinPokemonAmount, possibleLimitInThisIteration)
+                        });
+                    }
+                    else
+                    {
+                        session.EventDispatcher.Send(new NoticeEvent()
+                        {
+                            Message = session.Translation.GetTranslation(TranslationString.CatchMorePokemonToUseLuckyEgg,
+                                deltaPokemonToUseLuckyEgg)
+                        });
+                    }
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/ILogicSettings.cs
+++ b/ILogicSettings.cs
@@ -1,0 +1,246 @@
+#region using directives
+
+using System.Collections.Generic;
+using PoGo.NecroBot.Logic.Model.Settings;
+using POGOProtos.Enums;
+using POGOProtos.Inventory.Item;
+using System.Threading;
+
+#endregion
+
+namespace PoGo.NecroBot.Logic.Interfaces.Configuration
+{
+
+    public interface ILogicSettings
+    {
+        bool UseWebsocket { get; }
+        bool CatchPokemon { get; }
+        int OutOfBallCatchBlockTime { get; }
+        int PokeballsToKeepForSnipe { get; }            
+        int CatchPokemonLimit { get; }
+        int CatchPokemonLimitMinutes { get; }
+        int PokeStopLimit { get; }
+        int PokeStopLimitMinutes { get; }
+        int SnipeCountLimit { get; }
+        int MinIVForAutoSnipe { get; }
+        int SnipeRestSeconds { get; }
+        bool TransferWeakPokemon { get; }
+        bool DisableHumanWalking { get; }
+        bool CheckForUpdates { get; }
+        bool AutoUpdate { get; }
+        float KeepMinIvPercentage { get; }
+        int KeepMinCp { get; }
+        int KeepMinLvl { get; }
+        bool UseKeepMinLvl { get; }
+        string KeepMinOperator { get; }
+        double WalkingSpeedInKilometerPerHour { get; }
+        bool UseWalkingSpeedVariant { get; }
+        double WalkingSpeedVariant { get; }
+        bool ShowVariantWalking { get; }
+        bool RandomlyPauseAtStops { get; }
+        bool FastSoftBanBypass { get; }
+        int ByPassSpinCount { get; }
+
+        bool EvolveAllPokemonWithEnoughCandy { get; }
+        bool KeepPokemonsThatCanEvolve { get; }
+
+        bool UseTransferFilterToCatch { get; }
+        bool TransferDuplicatePokemon { get; }
+        bool TransferDuplicatePokemonOnCapture { get; }
+        bool UseBulkTransferPokemon { get; }
+        bool UseEggIncubators { get; }
+        bool UseLimitedEggIncubators { get; }
+        int UseGreatBallAboveCp { get; }
+        int UseUltraBallAboveCp { get; }
+        int UseMasterBallAboveCp { get; }
+        double UseGreatBallAboveIv { get; }
+        double UseUltraBallAboveIv { get; }
+        double UseMasterBallBelowCatchProbability { get; }
+        double UseUltraBallBelowCatchProbability { get; }
+        double UseGreatBallBelowCatchProbability { get; }
+        bool EnableHumanizedThrows { get; }
+        bool EnableMissedThrows { get; }
+        int ThrowMissPercentage { get; }
+        int NiceThrowChance { get; }
+        int GreatThrowChance { get; }
+        int ExcellentThrowChance { get; }
+        int CurveThrowChance { get; }
+        double ForceGreatThrowOverIv { get; }
+        double ForceExcellentThrowOverIv { get; }
+        int ForceGreatThrowOverCp { get; }
+        int ForceExcellentThrowOverCp { get; }
+        int DelayBetweenPokemonCatch { get; }
+        int DelayBetweenPokemonUpgrade { get; }
+        bool AutomaticallyLevelUpPokemon { get; }
+        bool OnlyUpgradeFavorites { get; }
+        bool UseLevelUpList { get; }
+        string LevelUpByCPorIv { get; }
+        float UpgradePokemonCpMinimum { get; }
+        float UpgradePokemonIvMinimum { get; }
+        int DelayBetweenPlayerActions { get; }
+        bool UsePokemonToNotCatchFilter { get; }
+        bool UsePokemonSniperFilterOnly { get; }
+        int KeepMinDuplicatePokemon { get; }
+        bool PrioritizeIvOverCp { get; }
+        int AmountOfTimesToUpgradeLoop { get; }
+        int GetMinStarDustForLevelUp { get; }
+        bool UseLuckyEggConstantly { get; }
+        int MaxBerriesToUsePerPokemon { get; }
+        bool UseIncenseConstantly { get; }
+        float UseBerriesMinCp { get; }
+        float UseBerriesMinIv { get; }
+        double UseBerriesBelowCatchProbability { get; }
+        string UseBerriesOperator { get; }
+        string UpgradePokemonMinimumStatsOperator { get; }
+        int MaxTravelDistanceInMeters { get; }
+        bool UseGpxPathing { get; }
+        string GpxFile { get; }
+        bool UseLuckyEggsWhileEvolving { get; }
+        int UseLuckyEggsMinPokemonAmount { get; }
+        bool EvolveAllPokemonAboveIv { get; }
+        float EvolveAboveIvValue { get; }
+        bool DumpPokemonStats { get; }
+        bool RenamePokemon { get; }
+        bool RenameOnlyAboveIv { get; }
+        float FavoriteMinIvPercentage { get; }
+        bool AutoFavoritePokemon { get; }
+        string RenameTemplate { get; }
+        int AmountOfPokemonToDisplayOnStart { get; }
+        string TranslationLanguageCode { get; }
+        string ProfilePath { get; }
+        string ProfileConfigPath { get; }
+        string GeneralConfigPath { get; }
+        bool SnipeAtPokestops { get; }
+        bool ActivateMSniper { get; }
+        bool UseTelegramAPI { get; }
+        string TelegramAPIKey { get; }
+        string TelegramPassword { get; }
+        int MinPokeballsToSnipe { get; }
+        int MinPokeballsWhileSnipe { get; }
+        int MaxPokeballsPerPokemon { get; }
+        string SnipeLocationServer { get; }
+        int SnipeLocationServerPort { get; }
+        bool GetSniperInfoFromPokezz { get; }
+        bool GetOnlyVerifiedSniperInfoFromPokezz { get; }
+        bool GetSniperInfoFromPokeSnipers { get; }
+        bool GetSniperInfoFromPokeWatchers { get; }
+        bool GetSniperInfoFromSkiplagged { get; }
+        bool UseSnipeLocationServer { get; }
+        bool UseTransferIvForSnipe { get; }
+        bool SnipeIgnoreUnknownIv { get; }
+        int MinDelayBetweenSnipes { get; }
+        double SnipingScanOffset { get; }
+        bool SnipePokemonNotInPokedex { get; }
+        bool RandomizeRecycle { get; }
+        int RandomRecycleValue { get; }
+        int TotalAmountOfPokeballsToKeep { get; }
+        int MaxPokeballsToKeep { get; }
+
+        int TotalAmountOfPotionsToKeep { get; }
+        int TotalAmountOfRevivesToKeep { get; }
+        int TotalAmountOfBerriesToKeep { get; }
+        bool DetailedCountsBeforeRecycling { get; }
+        bool VerboseRecycling { get; }
+        double RecycleInventoryAtUsagePercentage { get; }
+        double EvolveKeptPokemonsAtStorageUsagePercentage { get; }
+        int EvolveKeptPokemonIfBagHasOverThisManyPokemon { get; }
+        bool UseSnipeLimit { get; }
+        bool UsePokeStopLimit { get; }
+        bool UseCatchLimit { get; }
+        bool UseNearActionRandom { get; }
+        ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter { get; }
+
+        ICollection<PokemonId> PokemonsToEvolve { get; }
+        ICollection<PokemonId> PokemonsToLevelUp { get; }
+
+        NotificationConfig NotificationConfig { get; }
+        ICollection<PokemonId> PokemonsNotToTransfer { get; }
+
+        ICollection<PokemonId> PokemonsNotToCatch { get; }
+
+        ICollection<PokemonId> PokemonToUseMasterball { get; }
+
+        Dictionary<PokemonId, TransferFilter> PokemonsTransferFilter { get; }
+        Dictionary<PokemonId, SnipeFilter> PokemonSnipeFilters { get; }
+        Dictionary<PokemonId, UpgradeFilter> PokemonUpgradeFilters { get; }
+
+        Dictionary<PokemonId, BotSwitchPokemonFilter> BotSwitchPokemonFilters { get; }
+
+        SnipeSettings PokemonToSnipe { get; }
+
+        bool StartupWelcomeDelay { get; }
+        bool UseGoogleWalk { get; }
+        double DefaultStepLength { get; }
+        bool UseGoogleWalkCache { get; }
+        string GoogleApiKey { get; }
+        string GoogleHeuristic { get; }
+        string GoogleElevationApiKey { get; }
+
+        bool UseYoursWalk { get; }
+        string YoursWalkHeuristic { get; }
+
+        bool UseMapzenWalk { get; }
+        string MapzenTurnByTurnApiKey { get; }
+        string MapzenWalkHeuristic { get; }
+        string MapzenElevationApiKey { get; }
+
+        int ResumeTrack { get; }
+        int ResumeTrackSeg { get; }
+        int ResumeTrackPt { get; }
+
+        bool EnableHumanWalkingSnipe { get; }
+        bool HumanWalkingSnipeDisplayList { get; }
+        double HumanWalkingSnipeMaxDistance { get; }
+        double HumanWalkingSnipeMaxEstimateTime { get; }
+        bool HumanWalkingSnipeTryCatchEmAll { get; }
+        int HumanWalkingSnipeCatchEmAllMinBalls { get; }
+        bool HumanWalkingSnipeCatchPokemonWhileWalking { get; }
+        bool HumanWalkingSnipeSpinWhileWalking { get; }
+        bool HumanWalkingSnipeAlwaysWalkBack { get; }
+        double HumanWalkingSnipeWalkbackDistanceLimit { get; }
+        double HumanWalkingSnipeSnipingScanOffset { get; }
+        bool HumanWalkingSnipeIncludeDefaultLocation { get; }
+        bool HumanWalkingSnipeUseSnipePokemonList { get; }
+        Dictionary<PokemonId, HumanWalkSnipeFilter> HumanWalkSnipeFilters { get; }
+        bool HumanWalkingSnipeAllowSpeedUp { get; }
+        double HumanWalkingSnipeMaxSpeedUpSpeed { get; }
+        int HumanWalkingSnipeDelayTimeAtDestination { get; }
+        bool HumanWalkingSnipeAllowTransferWhileWalking { get; }
+
+        bool HumanWalkingSnipeUsePokeRadar { get; }
+        bool HumanWalkingSnipeUseSkiplagged { get; }
+        bool HumanWalkingSnipeUsePokecrew { get; }
+        bool HumanWalkingSnipeUsePokesnipers { get; }
+        bool HumanWalkingSnipeUsePokeZZ { get; }
+        bool HumanWalkingSnipeUsePokeWatcher { get; }
+        bool HumanWalkingSnipeUseFastPokemap { get; }
+        bool HumanWalkingSnipeUsePogoLocationFeeder { get; }
+
+        int EvolveActionDelay { get; }
+        int TransferActionDelay { get; }
+        int RecycleActionDelay { get; }
+        int RenamePokemonActionDelay { get; }
+
+        bool GymAllowed { get; }
+        bool GymPrioritizeOverPokestop { get; }
+        TeamColor GymDefaultTeam { get; }
+        double GymMaxDistance { get; }
+        int GymMaxCPToDeploy {  get; }
+        int GymMaxLevelToDeploy { get; }
+        bool GymUseRandomPokemon { get; }
+        int GymVisitTimeout { get; }
+        int GymNumberOfTopPokemonToBeExcluded { get; }
+
+        string DataSharingIdentifiation { get; }
+        bool DataSharingEnable { get; }
+        string DataSharingDataUrl { get; }
+        bool AllowAutoSnipe { get; }
+        MultipleBotConfig MultipleBotConfig { get; }
+        int GymCollectRewardAfter { get; }
+        List<AuthConfig> Bots { get; }
+        bool AllowMultipleBot { get; }
+        CaptchaConfig CaptchaConfig { get;  }
+        int BulkTransferStogareBuffer { get;  }
+        bool AutosnipeVerifiedOnly { get;  }
+    }
+}

--- a/LogicSettings.cs
+++ b/LogicSettings.cs
@@ -1,0 +1,253 @@
+#region using directives
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PoGo.NecroBot.Logic.Interfaces.Configuration;
+using POGOProtos.Enums;
+using POGOProtos.Inventory.Item;
+
+#endregion
+
+namespace PoGo.NecroBot.Logic.Model.Settings
+{
+    public class LogicSettings : ILogicSettings
+    {
+        private readonly GlobalSettings _settings;
+
+        public LogicSettings(GlobalSettings settings)
+        {
+            _settings = settings;
+        }
+
+        public string ProfilePath => _settings.ProfilePath;
+        public string ProfileConfigPath => _settings.ProfileConfigPath;
+        public string GeneralConfigPath => _settings.GeneralConfigPath;
+        public int SchemaVersion => _settings.UpdateConfig.SchemaVersion;
+        public bool CheckForUpdates => _settings.UpdateConfig.CheckForUpdates;
+        public bool AutoUpdate => _settings.UpdateConfig.AutoUpdate;
+        public bool UseWebsocket => _settings.WebsocketsConfig.UseWebsocket;
+        public bool CatchPokemon => _settings.PokemonConfig.CatchPokemon;
+        public int OutOfBallCatchBlockTime => _settings.PokemonConfig.OutOfBallCatchBlockTime;
+        public int PokeballToKeepForSnipe => _settings.PokemonConfig.PokeballToKeepForSnipe;
+        public int PokeballsToKeepForSnipe => _settings.PokemonConfig.PokeballToKeepForSnipe;
+
+        public int CatchPokemonLimit => _settings.PokemonConfig.CatchPokemonLimit;
+        public int CatchPokemonLimitMinutes => _settings.PokemonConfig.CatchPokemonLimitMinutes;
+        public int PokeStopLimit => _settings.PokeStopConfig.PokeStopLimit;
+        public int PokeStopLimitMinutes => _settings.PokeStopConfig.PokeStopLimitMinutes;
+        public int SnipeCountLimit => _settings.SnipeConfig.SnipeCountLimit;
+        public int SnipeRestSeconds => _settings.SnipeConfig.SnipeRestSeconds;
+        public bool TransferWeakPokemon => _settings.PokemonConfig.TransferWeakPokemon;
+        public bool DisableHumanWalking => _settings.LocationConfig.DisableHumanWalking;
+        public int MaxBerriesToUsePerPokemon => _settings.PokemonConfig.MaxBerriesToUsePerPokemon;
+        public float KeepMinIvPercentage => _settings.PokemonConfig.KeepMinIvPercentage;
+        public string KeepMinOperator => _settings.PokemonConfig.KeepMinOperator;
+        public int KeepMinCp => _settings.PokemonConfig.KeepMinCp;
+        public int KeepMinLvl => _settings.PokemonConfig.KeepMinLvl;
+        public bool UseKeepMinLvl => _settings.PokemonConfig.UseKeepMinLvl;
+        public bool AutomaticallyLevelUpPokemon => _settings.PokemonConfig.AutomaticallyLevelUpPokemon;
+        public bool OnlyUpgradeFavorites => _settings.PokemonConfig.OnlyUpgradeFavorites;
+        public bool UseLevelUpList => _settings.PokemonConfig.UseLevelUpList;
+        public int AmountOfTimesToUpgradeLoop => _settings.PokemonConfig.AmountOfTimesToUpgradeLoop;
+        public string LevelUpByCPorIv => _settings.PokemonConfig.LevelUpByCPorIv;
+        public int GetMinStarDustForLevelUp => _settings.PokemonConfig.GetMinStarDustForLevelUp;
+        public bool UseLuckyEggConstantly => _settings.PokemonConfig.UseLuckyEggConstantly;
+        public bool UseIncenseConstantly => _settings.PokemonConfig.UseIncenseConstantly;
+        public float UseBerriesMinCp => _settings.PokemonConfig.UseBerriesMinCp;
+        public float UseBerriesMinIv => _settings.PokemonConfig.UseBerriesMinIv;
+        public double UseBerriesBelowCatchProbability => _settings.PokemonConfig.UseBerriesBelowCatchProbability;
+        public string UseBerriesOperator => _settings.PokemonConfig.UseBerriesOperator;
+        public float UpgradePokemonIvMinimum => _settings.PokemonConfig.UpgradePokemonIvMinimum;
+        public float UpgradePokemonCpMinimum => _settings.PokemonConfig.UpgradePokemonCpMinimum;
+        public string UpgradePokemonMinimumStatsOperator => _settings.PokemonConfig.UpgradePokemonMinimumStatsOperator;
+        public double WalkingSpeedInKilometerPerHour => _settings.LocationConfig.WalkingSpeedInKilometerPerHour;
+        public bool UseWalkingSpeedVariant => _settings.LocationConfig.UseWalkingSpeedVariant;
+        public double WalkingSpeedVariant => _settings.LocationConfig.WalkingSpeedVariant;
+        public bool ShowVariantWalking => _settings.LocationConfig.ShowVariantWalking;
+        public bool FastSoftBanBypass => _settings.SoftBanConfig.FastSoftBanBypass;
+        public int ByPassSpinCount  =>  _settings.SoftBanConfig.ByPassSpinCount;
+        public bool EvolveAllPokemonWithEnoughCandy => _settings.PokemonConfig.EvolveAllPokemonWithEnoughCandy;
+        public bool KeepPokemonsThatCanEvolve => _settings.PokemonConfig.KeepPokemonsThatCanEvolve;
+        public bool TransferDuplicatePokemon => _settings.PokemonConfig.TransferDuplicatePokemon;
+        public bool TransferDuplicatePokemonOnCapture => _settings.PokemonConfig.TransferDuplicatePokemonOnCapture;
+        public bool UseBulkTransferPokemon => _settings.PokemonConfig.UseBulkTransferPokemon;
+        public int BulkTransferStogareBuffer => _settings.PokemonConfig.BulkTransferStogareBuffer;
+
+        public bool UseEggIncubators => _settings.PokemonConfig.UseEggIncubators;
+        public bool UseLimitedEggIncubators => _settings.PokemonConfig.UseLimitedEggIncubators;
+        public int UseGreatBallAboveCp => _settings.PokemonConfig.UseGreatBallAboveCp;
+        public int UseUltraBallAboveCp => _settings.PokemonConfig.UseUltraBallAboveCp;
+        public int UseMasterBallAboveCp => _settings.PokemonConfig.UseMasterBallAboveCp;
+        public double UseGreatBallAboveIv => _settings.PokemonConfig.UseGreatBallAboveIv;
+        public double UseUltraBallAboveIv => _settings.PokemonConfig.UseUltraBallAboveIv;
+        public double UseMasterBallBelowCatchProbability => _settings.PokemonConfig.UseMasterBallBelowCatchProbability;
+        public double UseUltraBallBelowCatchProbability => _settings.PokemonConfig.UseUltraBallBelowCatchProbability;
+        public double UseGreatBallBelowCatchProbability => _settings.PokemonConfig.UseGreatBallBelowCatchProbability;
+        public bool EnableHumanizedThrows => _settings.CustomCatchConfig.EnableHumanizedThrows;
+        public bool EnableMissedThrows => _settings.CustomCatchConfig.EnableMissedThrows;
+        public int ThrowMissPercentage => _settings.CustomCatchConfig.ThrowMissPercentage;
+        public int NiceThrowChance => _settings.CustomCatchConfig.NiceThrowChance;
+        public int GreatThrowChance => _settings.CustomCatchConfig.GreatThrowChance;
+        public int ExcellentThrowChance => _settings.CustomCatchConfig.ExcellentThrowChance;
+        public int CurveThrowChance => _settings.CustomCatchConfig.CurveThrowChance;
+        public double ForceGreatThrowOverIv => _settings.CustomCatchConfig.ForceGreatThrowOverIv;
+        public double ForceExcellentThrowOverIv => _settings.CustomCatchConfig.ForceExcellentThrowOverIv;
+        public int ForceGreatThrowOverCp => _settings.CustomCatchConfig.ForceGreatThrowOverCp;
+        public int ForceExcellentThrowOverCp => _settings.CustomCatchConfig.ForceExcellentThrowOverCp;
+        public int DelayBetweenPokemonUpgrade => _settings.PokemonConfig.DelayBetweenPokemonUpgrade;
+        public int DelayBetweenPokemonCatch => _settings.PokemonConfig.DelayBetweenPokemonCatch;
+
+        public int DelayBetweenPlayerActions => _settings.PlayerConfig.DelayBetweenPlayerActions;
+        public int EvolveActionDelay => _settings.PlayerConfig.EvolveActionDelay;
+        public int TransferActionDelay => _settings.PlayerConfig.TransferActionDelay;
+        public int RecycleActionDelay => _settings.PlayerConfig.RecycleActionDelay;
+        public int RenamePokemonActionDelay => _settings.PlayerConfig.RenamePokemonActionDelay;
+        public bool UseNearActionRandom => _settings.PlayerConfig.UseNearActionRandom;
+        public bool UsePokemonToNotCatchFilter => _settings.PokemonConfig.UsePokemonToNotCatchFilter;
+        public bool UsePokemonSniperFilterOnly => _settings.PokemonConfig.UsePokemonSniperFilterOnly;
+        public int KeepMinDuplicatePokemon => _settings.PokemonConfig.KeepMinDuplicatePokemon;
+        public bool PrioritizeIvOverCp => _settings.PokemonConfig.PrioritizeIvOverCp;
+        public int MaxTravelDistanceInMeters => _settings.LocationConfig.MaxTravelDistanceInMeters;
+        public string GpxFile => _settings.GPXConfig.GpxFile;
+        public bool UseGpxPathing => _settings.GPXConfig.UseGpxPathing;
+        public bool UseLuckyEggsWhileEvolving => _settings.PokemonConfig.UseLuckyEggsWhileEvolving;
+        public int UseLuckyEggsMinPokemonAmount => _settings.PokemonConfig.UseLuckyEggsMinPokemonAmount;
+        public bool EvolveAllPokemonAboveIv => _settings.PokemonConfig.EvolveAllPokemonAboveIv;
+        public float EvolveAboveIvValue => _settings.PokemonConfig.EvolveAboveIvValue;
+        public bool RenamePokemon => _settings.PokemonConfig.RenamePokemon;
+        public bool RenameOnlyAboveIv => _settings.PokemonConfig.RenameOnlyAboveIv;
+        public float FavoriteMinIvPercentage => _settings.PokemonConfig.FavoriteMinIvPercentage;
+        public bool AutoFavoritePokemon => _settings.PokemonConfig.AutoFavoritePokemon;
+        public string RenameTemplate => _settings.PokemonConfig.RenameTemplate;
+        public int AmountOfPokemonToDisplayOnStart => _settings.ConsoleConfig.AmountOfPokemonToDisplayOnStart;
+        public bool DumpPokemonStats => _settings.PokemonConfig.DumpPokemonStats;
+        public string TranslationLanguageCode => _settings.ConsoleConfig.TranslationLanguageCode;
+        public bool DetailedCountsBeforeRecycling => _settings.ConsoleConfig.DetailedCountsBeforeRecycling;
+        public bool VerboseRecycling => _settings.RecycleConfig.VerboseRecycling;
+        public double RecycleInventoryAtUsagePercentage => _settings.RecycleConfig.RecycleInventoryAtUsagePercentage;
+        public double EvolveKeptPokemonsAtStorageUsagePercentage => _settings.PokemonConfig.EvolveKeptPokemonsAtStorageUsagePercentage;
+        public int EvolveKeptPokemonIfBagHasOverThisManyPokemon => _settings.PokemonConfig.EvolveKeptPokemonIfBagHasOverThisManyPokemon;
+        public ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter => _settings.ItemRecycleFilter.Select(itemRecycleFilter => new KeyValuePair<ItemId, int>(itemRecycleFilter.Key, itemRecycleFilter.Value)).ToList();
+        public ICollection<PokemonId> PokemonsToEvolve => _settings.PokemonsToEvolve;
+        public ICollection<PokemonId> PokemonsToLevelUp => _settings.PokemonsToLevelUp;
+        public ICollection<PokemonId> PokemonsNotToTransfer => _settings.PokemonsNotToTransfer;
+        public ICollection<PokemonId> PokemonsNotToCatch => _settings.PokemonsToIgnore;
+
+        public ICollection<PokemonId> PokemonToUseMasterball => _settings.PokemonToUseMasterball;
+        public Dictionary<PokemonId, TransferFilter> PokemonsTransferFilter => _settings.PokemonsTransferFilter;
+        public Dictionary<PokemonId, UpgradeFilter> PokemonUpgradeFilters => _settings.PokemonUpgradeFilters;
+        public Dictionary<PokemonId, SnipeFilter> PokemonSnipeFilters => _settings.SnipePokemonFilter;
+
+        public bool StartupWelcomeDelay => _settings.ConsoleConfig.StartupWelcomeDelay;
+        public bool UseGoogleWalk => _settings.GoogleWalkConfig.UseGoogleWalk;
+        public double DefaultStepLength => _settings.GoogleWalkConfig.DefaultStepLength;
+        public bool UseGoogleWalkCache => _settings.GoogleWalkConfig.Cache;
+        public string GoogleApiKey => _settings.GoogleWalkConfig.GoogleAPIKey;
+        public string GoogleHeuristic => _settings.GoogleWalkConfig.GoogleHeuristic;
+        public string GoogleElevationApiKey => _settings.GoogleWalkConfig.GoogleElevationAPIKey;
+
+        public bool UseYoursWalk => _settings.YoursWalkConfig.UseYoursWalk;
+        public string YoursWalkHeuristic => _settings.YoursWalkConfig.YoursWalkHeuristic;
+
+        public bool UseMapzenWalk => _settings.MapzenWalkConfig.UseMapzenWalk;
+        public string MapzenTurnByTurnApiKey => _settings.MapzenWalkConfig.MapzenTurnByTurnApiKey;
+        public string MapzenWalkHeuristic => _settings.MapzenWalkConfig.MapzenWalkHeuristic;
+        public string MapzenElevationApiKey => _settings.MapzenWalkConfig.MapzenElevationApiKey;
+
+        public bool SnipeAtPokestops => _settings.SnipeConfig.SnipeAtPokestops;
+        public bool ActivateMSniper => _settings.SnipeConfig.ActivateMSniper;
+        public bool UseTelegramAPI => _settings.TelegramConfig.UseTelegramAPI;
+        public string TelegramAPIKey => _settings.TelegramConfig.TelegramAPIKey;
+        public string TelegramPassword => _settings.TelegramConfig.TelegramPassword;
+        public int MinPokeballsToSnipe => _settings.SnipeConfig.MinPokeballsToSnipe;
+        public int MinPokeballsWhileSnipe => _settings.SnipeConfig.MinPokeballsWhileSnipe;
+        public int MaxPokeballsPerPokemon => _settings.PokemonConfig.MaxPokeballsPerPokemon;
+        public bool RandomlyPauseAtStops => _settings.LocationConfig.RandomlyPauseAtStops;
+        public SnipeSettings PokemonToSnipe => _settings.PokemonToSnipe;
+        public string SnipeLocationServer => _settings.SnipeConfig.SnipeLocationServer;
+        public int SnipeLocationServerPort => _settings.SnipeConfig.SnipeLocationServerPort;
+        public bool GetSniperInfoFromPokezz => _settings.SnipeConfig.GetSniperInfoFromPokezz;
+        public bool GetOnlyVerifiedSniperInfoFromPokezz => _settings.SnipeConfig.GetOnlyVerifiedSniperInfoFromPokezz;
+        public bool GetSniperInfoFromPokeSnipers => _settings.SnipeConfig.GetSniperInfoFromPokeSnipers;
+        public bool GetSniperInfoFromPokeWatchers => _settings.SnipeConfig.GetSniperInfoFromPokeWatchers;
+        public bool GetSniperInfoFromSkiplagged => _settings.SnipeConfig.GetSniperInfoFromSkiplagged;
+        public bool UseSnipeLocationServer => _settings.SnipeConfig.UseSnipeLocationServer;
+        public bool UseTransferIvForSnipe => _settings.SnipeConfig.UseTransferIvForSnipe;
+        public bool SnipeIgnoreUnknownIv => _settings.SnipeConfig.SnipeIgnoreUnknownIv;
+        public int MinDelayBetweenSnipes => _settings.SnipeConfig.MinDelayBetweenSnipes;
+        public double SnipingScanOffset => _settings.SnipeConfig.SnipingScanOffset;
+        public bool SnipePokemonNotInPokedex => _settings.SnipeConfig.SnipePokemonNotInPokedex;
+        public bool RandomizeRecycle => _settings.RecycleConfig.RandomizeRecycle;
+        public int RandomRecycleValue => _settings.RecycleConfig.RandomRecycleValue;
+        public int MaxPokeballsToKeep => _settings.RecycleConfig.MaxPokeballsToKeep;
+        public int TotalAmountOfPokeballsToKeep => _settings.RecycleConfig.TotalAmountOfPokeballsToKeep;
+        public int TotalAmountOfPotionsToKeep => _settings.RecycleConfig.TotalAmountOfPotionsToKeep;
+        public int TotalAmountOfRevivesToKeep => _settings.RecycleConfig.TotalAmountOfRevivesToKeep;
+        public int TotalAmountOfBerriesToKeep => _settings.RecycleConfig.TotalAmountOfBerriesToKeep;
+        public bool UseSnipeLimit => _settings.SnipeConfig.UseSnipeLimit;
+        public bool UsePokeStopLimit => _settings.PokeStopConfig.UsePokeStopLimit;
+        public bool UseCatchLimit => _settings.PokemonConfig.UseCatchLimit;
+        public int ResumeTrack => _settings.LocationConfig.ResumeTrack;
+        public int ResumeTrackSeg => _settings.LocationConfig.ResumeTrackSeg;
+        public int ResumeTrackPt => _settings.LocationConfig.ResumeTrackPt;
+        public bool EnableHumanWalkingSnipe => _settings.HumanWalkSnipeConfig.Enable;
+        public bool HumanWalkingSnipeDisplayList => _settings.HumanWalkSnipeConfig.DisplayPokemonList;
+        public double HumanWalkingSnipeMaxDistance => _settings.HumanWalkSnipeConfig.MaxDistance;
+        public double HumanWalkingSnipeMaxEstimateTime => _settings.HumanWalkSnipeConfig.MaxEstimateTime;
+        public bool HumanWalkingSnipeTryCatchEmAll => _settings.HumanWalkSnipeConfig.TryCatchEmAll;
+        public int HumanWalkingSnipeCatchEmAllMinBalls => _settings.HumanWalkSnipeConfig.CatchEmAllMinBalls;
+        public bool HumanWalkingSnipeCatchPokemonWhileWalking => _settings.HumanWalkSnipeConfig.CatchPokemonWhileWalking;
+        public bool HumanWalkingSnipeSpinWhileWalking => _settings.HumanWalkSnipeConfig.SpinWhileWalking;
+        public bool HumanWalkingSnipeAlwaysWalkBack => _settings.HumanWalkSnipeConfig.AlwaysWalkback;
+        public double HumanWalkingSnipeWalkbackDistanceLimit => _settings.HumanWalkSnipeConfig.WalkbackDistanceLimit;
+        public double HumanWalkingSnipeSnipingScanOffset => _settings.HumanWalkSnipeConfig.SnipingScanOffset;
+        public bool HumanWalkingSnipeIncludeDefaultLocation => _settings.HumanWalkSnipeConfig.IncludeDefaultLocation;
+        public bool HumanWalkingSnipeUseSnipePokemonList => _settings.HumanWalkSnipeConfig.UseSnipePokemonList;
+        public Dictionary<PokemonId, HumanWalkSnipeFilter> HumanWalkSnipeFilters => _settings.HumanWalkSnipeFilters;
+        public bool HumanWalkingSnipeAllowSpeedUp => _settings.HumanWalkSnipeConfig.AllowSpeedUp;
+        public double HumanWalkingSnipeMaxSpeedUpSpeed => _settings.HumanWalkSnipeConfig.MaxSpeedUpSpeed;
+        public int HumanWalkingSnipeDelayTimeAtDestination => _settings.HumanWalkSnipeConfig.DelayTimeAtDestination;
+        public bool HumanWalkingSnipeUsePokeRadar => _settings.HumanWalkSnipeConfig.UsePokeRadar;
+        public bool HumanWalkingSnipeUseSkiplagged => _settings.HumanWalkSnipeConfig.UseSkiplagged;
+        public bool HumanWalkingSnipeUsePokecrew => _settings.HumanWalkSnipeConfig.UsePokecrew;
+        public bool HumanWalkingSnipeUsePokesnipers => _settings.HumanWalkSnipeConfig.UsePokesnipers;
+        public bool HumanWalkingSnipeUsePokeZZ => _settings.HumanWalkSnipeConfig.UsePokeZZ;
+        public bool HumanWalkingSnipeUsePokeWatcher => _settings.HumanWalkSnipeConfig.UsePokeWatcher;
+        public bool HumanWalkingSnipeUseFastPokemap => _settings.HumanWalkSnipeConfig.UseFastPokemap;
+        public bool HumanWalkingSnipeUsePogoLocationFeeder => _settings.HumanWalkSnipeConfig.UsePogoLocationFeeder;
+        public bool HumanWalkingSnipeAllowTransferWhileWalking => _settings.HumanWalkSnipeConfig.AllowTransferWhileWalking;
+        public int GymCollectRewardAfter => _settings.GymConfig.CollectCoinAfterDeployed;
+        public bool GymAllowed => _settings.GymConfig.Enable;
+        public bool GymPrioritizeOverPokestop => _settings.GymConfig.PrioritizeGymOverPokestop;
+        public TeamColor GymDefaultTeam =>(TeamColor)Enum.Parse(typeof(TeamColor), _settings.GymConfig.DefaultTeam);
+
+        public double GymMaxDistance => _settings.GymConfig.MaxDistance;
+        public int GymVisitTimeout => _settings.GymConfig.VisitTimeout;
+        public int GymMaxCPToDeploy => _settings.GymConfig.MaxCPToDeploy;
+        public int GymMaxLevelToDeploy => _settings.GymConfig.MaxLevelToDeploy;
+
+        public bool GymUseRandomPokemon => _settings.GymConfig.UseRandomPokemon;
+
+        public int GymNumberOfTopPokemonToBeExcluded => _settings.GymConfig.NumberOfTopPokemonToBeExcluded;
+
+        public bool DataSharingEnable => _settings.DataSharingConfig.EnableSyncData;
+        public string DataSharingIdentifiation => _settings.DataSharingConfig.DataServiceIdentification;
+        public bool AllowAutoSnipe => _settings.DataSharingConfig.AutoSnipe;
+
+        public string DataSharingDataUrl => _settings.DataSharingConfig.DataRecieverURL;
+
+        public bool UseTransferFilterToCatch => _settings.CustomCatchConfig.UseTransferFilterToCatch;
+
+        public MultipleBotConfig MultipleBotConfig => _settings.MultipleBotConfig;
+        public List<AuthConfig> Bots => _settings.Auth.Bots;
+        public bool AllowMultipleBot => _settings.Auth.AllowMultipleBot;
+        public int MinIVForAutoSnipe => _settings.SnipeConfig.MinIVForAutoSnipe;
+        public bool AutosnipeVerifiedOnly => _settings.SnipeConfig.AutosnipeVerifiedOnly;
+        public Dictionary<PokemonId, BotSwitchPokemonFilter> BotSwitchPokemonFilters => _settings.BotSwitchPokemonFilters;
+
+        public NotificationConfig NotificationConfig => _settings.NotificationConfig;
+
+        public CaptchaConfig CaptchaConfig => _settings.CaptchaConfig;
+    }
+}

--- a/PokemonConfig.cs
+++ b/PokemonConfig.cs
@@ -1,0 +1,395 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using Newtonsoft.Json;
+
+namespace PoGo.NecroBot.Logic.Model.Settings
+{
+    [JsonObject(Title = "Pokemon Config", Description = "Set your pokemon settings.", ItemRequired = Required.DisallowNull)]
+    public class PokemonConfig  :BaseConfig
+    {
+        public PokemonConfig() :base()
+        {
+
+        }
+
+        internal enum Operator
+        {
+            or,
+            and
+        }
+
+        internal enum CpIv
+        {
+            cp,
+            iv
+        }
+
+        [ExcelConfig (Description ="Allow bot catch pokemon", Position =1) ]
+        /*Catch*/
+        [DefaultValue(true)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 1)]
+        public bool CatchPokemon { get; set; }
+
+        [ExcelConfig(Description = "Delay time between 2 time catch pokemon ", Position = 2)]
+        [DefaultValue(2000)]
+        [Range(0, 99999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 2)]
+        public int DelayBetweenPokemonCatch{ get; set; }
+
+        /*CatchLimit*/
+        [ExcelConfig(Description = "Check for daily limit catch rate - 1000/24h", Position = 3)]
+        [DefaultValue(true)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 3)]
+        public bool UseCatchLimit { get; set; }
+
+        [ExcelConfig(Description = "Number of pokemon allow for catch duration", Position = 4)]
+        [DefaultValue(998)]
+        [Range(0, 9999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 4)]
+        public int CatchPokemonLimit{ get; set; }
+
+        [ExcelConfig(Description = "Catch duration apply for catch limit  & number", Position = 5)]
+        [DefaultValue(60 * 24 + 30)]
+        [Range(0, 9999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 5)]
+        public int CatchPokemonLimitMinutes{ get; set; }
+
+        /*Incense*/
+        [ExcelConfig(Description = "Allow bot use Incense ", Position = 6)]
+        [DefaultValue(false)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 6)]
+        public bool UseIncenseConstantly;
+
+        /*Egg*/
+        [ExcelConfig(Description = "Allow bot put egg in Incubator for hatching", Position = 7)]
+        [DefaultValue(true)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 7)]
+        public bool UseEggIncubators { get; set; }
+
+        [ExcelConfig(Description = "TUrn this on bot only put 10km egg in to non infinity incubator", Position = 8)]
+        [DefaultValue(true)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 8)]
+        public bool UseLimitedEggIncubators { get; set; }
+
+        [ExcelConfig(Description = "Turn on to allow bot always use lucky egg when they are available in bag", Position = 9)]
+        [DefaultValue(false)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 9)]
+        public bool UseLuckyEggConstantly;
+
+        [ExcelConfig(Description = "Number of pokemon ready for evolve that can use lucky egg", Position = 10)]
+        [DefaultValue(30)]
+        [Range(0, 999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 10)]
+        public int UseLuckyEggsMinPokemonAmount{ get; set; }
+
+        [ExcelConfig(Description = "Allow bot use lucky egg when evolve pokemon", Position = 11)]
+        [DefaultValue(false)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 11)]
+        public bool UseLuckyEggsWhileEvolving;
+
+        /*Berries*/
+        [ExcelConfig(Description = "Specify min CP will be use berries when catch", Position = 12)]
+        [DefaultValue(1000)]
+        [Range(0, 9999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 12)]
+        public int UseBerriesMinCp{ get; set; }
+
+        [ExcelConfig(Description = "Specify min IV will be use berries when catch", Position = 13)]
+        [DefaultValue(90)]
+        [Range(0, 100)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 13)]
+        public float UseBerriesMinIv{ get; set; }
+
+        [ExcelConfig(Description = "Specify max catch chance  will be use berries when catch", Position = 14)]
+        [DefaultValue(0.20)]
+        [Range(0, 1)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 14)]
+        public double UseBerriesBelowCatchProbability{ get; set; }
+
+        [ExcelConfig(Description = "The operator logic for berry use", Position = 15)]
+        [DefaultValue("or")]
+        [EnumDataType(typeof(Operator))]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 15)]
+        public string UseBerriesOperator{ get; set; }
+
+        [ExcelConfig(Description = "Number of berries can be used for 1 pokemon", Position = 16)]
+        [DefaultValue(30)]
+        [Range(0, 999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 16)]
+        public int MaxBerriesToUsePerPokemon{ get; set; }
+
+        /*Transfer*/
+        [ExcelConfig(Description = "Allow bot transfer weeak/low cp pokemon", Position = 17)]
+        [DefaultValue(false)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 17)]
+        public bool TransferWeakPokemon;
+
+        [ExcelConfig(Description = "Alow bot transfer all duplicate pokemon", Position = 18)]
+        [DefaultValue(true)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 18)]
+        public bool TransferDuplicatePokemon { get; set; }
+
+        [ExcelConfig(Description = "Allow bo transfer duplicated pokemon right after catch", Position = 19)]
+        [DefaultValue(true)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 19)]
+        public bool TransferDuplicatePokemonOnCapture { get; set; }
+
+        /*Rename*/
+        [ExcelConfig(Description = "Allow bot rename pokemon after catch", Position = 20)]
+        [DefaultValue(false)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 20)]
+        public bool RenamePokemon;
+
+        [ExcelConfig(Description = "Set Min IV for rename , bot only rename pokemon has IV higher then this value", Position = 21)]
+        [DefaultValue(false)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 21)]
+        public bool RenameOnlyAboveIv;
+
+        [ExcelConfig(Description = "The template for pokemon rename", Position = 22)]
+        [DefaultValue("{1}_{0}")]
+        [MinLength(0)]
+        [MaxLength(32)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 22)]
+        public string RenameTemplate{ get; set; }
+
+        /*Favorite*/
+        [ExcelConfig(Description = "Set min IV for auto favorite pokemon", Position = 23)]
+        [DefaultValue(95)]
+        [Range(0, 100)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 23)]
+        public float FavoriteMinIvPercentage{ get; set; }
+
+        [ExcelConfig(Description = "Allow bot auto favorite pokemon after catch", Position = 24)]
+        [DefaultValue(false)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 24)]
+        public bool AutoFavoritePokemon;
+
+        /*PokeBalls*/
+        [ExcelConfig(Description = "Number of balls will be use for catch a pokemon", Position = 25)]
+        [DefaultValue(6)]
+        [Range(0, 999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 25)]
+        public int MaxPokeballsPerPokemon{ get; set; }
+
+        [ExcelConfig(Description = "Define min CP for use greate ball instead of poke ball", Position = 26)]
+        [DefaultValue(1000)]
+        [Range(0, 9999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 26)]
+        public int UseGreatBallAboveCp{ get; set; }
+
+        [ExcelConfig(Description = "Define min CP for use ultra ball instead of greate ball", Position = 27)]
+        [DefaultValue(1250)]
+        [Range(0, 9999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 27)]
+        public int UseUltraBallAboveCp{ get; set; }
+
+        [ExcelConfig(Description = "Define min CP for use master ball instead of ultra ball", Position = 28)]
+        [DefaultValue(1500)]
+        [Range(0, 9999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 28)]
+        public int UseMasterBallAboveCp{ get; set; }
+
+        [ExcelConfig(Description = "Define min IV for use greate ball instead of poke ball", Position = 29)]
+        [DefaultValue(85.0)]
+        [Range(0, 100)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 29)]
+        public double UseGreatBallAboveIv{ get; set; }
+
+        [ExcelConfig(Description = "Define min CP for use ultra ball instead of greate ball", Position = 30)]
+        [DefaultValue(95.0)]
+        [Range(0, 100)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 30)]
+        public double UseUltraBallAboveIv{ get; set; }
+
+        [ExcelConfig(Description = "Define min catch probability for use greate ball instead of pokemon ball", Position = 31)]
+        [DefaultValue(0.2)]
+        [Range(0, 1)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 31)]
+        public double UseGreatBallBelowCatchProbability{ get; set; }
+
+        [ExcelConfig(Description = "Define min catch probability for use ultra ball instead of greate ball", Position = 32)]
+        [DefaultValue(0.1)]
+        [Range(0, 1)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 32)]
+        public double UseUltraBallBelowCatchProbability{ get; set; }
+
+        [ExcelConfig(Description = "Define min catch probability for use master ball instead of ultra ball", Position = 33)]
+        [DefaultValue(0.05)]
+        [Range(0, 999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 33)]
+        public double UseMasterBallBelowCatchProbability{ get; set; }
+
+        /*PoweUp*/
+        [ExcelConfig(Description = "Allow bot power up pokemon ", Position = 34)]
+        [DefaultValue(false)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 34)]
+        public bool AutomaticallyLevelUpPokemon;
+
+        [ExcelConfig(Description = "Only allow bot upgrade favorited pokemon", Position = 35)]
+        [DefaultValue(true)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 35)]
+        public bool OnlyUpgradeFavorites { get; set; }
+
+        [ExcelConfig(Description = "Use level up list pokemon", Position = 36)]
+        [DefaultValue(true)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 36)]
+        public bool UseLevelUpList { get; set; }
+
+        [ExcelConfig(Description = "Number of time upgrade 1 pokemon", Position = 37)]
+        [DefaultValue(5)]
+        [Range(0, 99)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 37)]
+        public int AmountOfTimesToUpgradeLoop{ get; set; }
+
+        [ExcelConfig(Description = "Min startdust keep for auto power up", Position = 38)]
+        [DefaultValue(5000)]
+        [Range(0, 999999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 38)]
+        public int GetMinStarDustForLevelUp{ get; set; }
+
+        [ExcelConfig(Description = "Select pokemon to powerup by IV or CP", Position = 39)]
+        [DefaultValue("iv")]
+        [EnumDataType(typeof(CpIv))]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 39)]
+        public string LevelUpByCPorIv{ get; set; }
+
+        [ExcelConfig(Description = "MIn CP for pokemon upgrade", Position = 40)]
+        [DefaultValue(1000)]
+        [Range(0, 9999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 40)]
+        public float UpgradePokemonCpMinimum{ get; set; }
+
+        [ExcelConfig(Description = "MIn IV for pokemon upgrade", Position = 41)]
+        [DefaultValue(95)]
+        [Range(0, 100)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 41)]
+        public float UpgradePokemonIvMinimum{ get; set; }
+
+        [ExcelConfig(Description = "Logic operator for select pokemon for upgrade", Position = 42)]
+        [DefaultValue("and")]
+        [EnumDataType(typeof(Operator))]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 42)]
+        public string UpgradePokemonMinimumStatsOperator{ get; set; }
+
+        /*Evolve*/
+        [ExcelConfig(Description = "Specify min IV for evolve pokemon", Position = 43)]
+        [DefaultValue(95)]
+        [Range(0, 100)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 43)]
+        public float EvolveAboveIvValue{ get; set; }
+
+        [ExcelConfig(Description = "Allow bot evolve all pokemon above this IV", Position = 44)]
+        [DefaultValue(false)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 44)]
+        public bool EvolveAllPokemonAboveIv;
+
+        [ExcelConfig(Description = "When turn on, bot will evolve pokemon when has enought candy", Position = 45)]
+        [DefaultValue(true)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 45)]
+        public bool EvolveAllPokemonWithEnoughCandy { get; set; }
+
+        [ExcelConfig(Description = "Specify the max storage pokemon bag for trigger evolve", Position = 46)]
+        [DefaultValue(90)]
+        [Range(0, 100)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 46)]
+        public double EvolveKeptPokemonsAtStorageUsagePercentage{ get; set; }
+
+        [ExcelConfig(Description = "Specify the pokemon to keep for mass evolve", Position = 47)]
+        [DefaultValue(120)]
+        [Range(0, 999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 47)]
+        public int EvolveKeptPokemonIfBagHasOverThisManyPokemon = 120;
+        
+        /*Keep*/
+        [ExcelConfig(Description = "Allow bot keep low candy pokemon for evolve", Position = 47)]
+        [DefaultValue(false)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 48)]
+        public bool KeepPokemonsThatCanEvolve;
+
+        [ExcelConfig(Description = "Specify min CP to not transfer pokemon", Position = 48)]
+        [DefaultValue(1250)]
+        [Range(0, 9999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 49)]
+        public int KeepMinCp{ get; set; }
+
+        [ExcelConfig(Description = "Specify min IV to not transfer pokemon", Position = 49)]
+        [DefaultValue(90)]
+        [Range(0, 100)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 50)]
+        public float KeepMinIvPercentage{ get; set; }
+
+        [ExcelConfig(Description = "Specify min LV to not transfer pokemon", Position = 50)]
+        [DefaultValue(6)]
+        [Range(0, 100)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 51)]
+        public int KeepMinLvl{ get; set; }
+
+        [ExcelConfig(Description = "Logic operator for keep pokemon check", Position = 51)]
+        [DefaultValue("or")]
+        [EnumDataType(typeof(Operator))]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 52)]
+        public string KeepMinOperator{ get; set; }
+
+        [ExcelConfig(Description = "Tell bot to check level before transfer", Position = 52)]
+        [DefaultValue(false)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 53)]
+        public bool UseKeepMinLvl;
+
+        [ExcelConfig(Description = "Keep pokemon has higher IV then CP to not transfer pokemon", Position = 53)]
+        [DefaultValue(true)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 53)]
+        public bool PrioritizeIvOverCp { get; set; }
+
+        [ExcelConfig(Description = "Number of duplicated pokemon to keep", Position = 54)]
+        [DefaultValue(1)]
+        [Range(0, 999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 54)]
+        public int KeepMinDuplicatePokemon{ get; set; }
+
+        /*NotCatch*/
+        [ExcelConfig(Description = "Use list pokemon not catch filter", Position = 55)]
+        [DefaultValue(true)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 55)]
+        public bool UsePokemonToNotCatchFilter { get; set; }
+
+        [ExcelConfig(Description = "UsePokemonSniperFilterOnly", Position = 56)]
+        [DefaultValue(false)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 56)]
+        public bool UsePokemonSniperFilterOnly{ get; set; }
+
+        /*Dump Stats*/
+        [ExcelConfig(Description = "Allow bot dump list pokemon to csv file", Position = 57)]
+        [DefaultValue(false)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 57)]
+        public bool DumpPokemonStats;
+
+        [DefaultValue(10000)]
+        [ExcelConfig(Description = "Delay time between pokemon upgrade", Position = 58)]
+        [Range(0, 99999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 58)]
+        public int DelayBetweenPokemonUpgrade{ get; set; }
+
+        [DefaultValue(5)]
+        [ExcelConfig(Description = "Temporary disable catch pokemon for certain minutes if bot run out of balls", Position = 59)]
+        [Range(0, 120)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 59)]
+        public int OutOfBallCatchBlockTime{ get; set; }
+
+        [DefaultValue(50)]
+        [ExcelConfig(Description = "Number of balls you want to save for snipe or manual play - it mean if total ball less than this value, catch pokemon will be deactive", Position = 60)]
+        [Range(0, 999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 60)]
+        public int PokeballToKeepForSnipe{ get; set; }
+
+        [DefaultValue(true)]
+        [ExcelConfig(Description = "Transfer multiple pokemon at 1 time - that will increase bot speed and reduce api call", Position = 61)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 61)]
+        public bool UseBulkTransferPokemon { get;  set; }
+
+        [DefaultValue(10)]
+        [ExcelConfig(Description = "Bot will transfer pokemons only when MaxStogare < pokemon + buffer", Position = 62)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 62)]
+        public int BulkTransferStogareBuffer { get;  set; }
+
+    }
+}


### PR DESCRIPTION
EvolveKeptPokemonsOverrideStartIfThisManyReady Should Be EvolveKeptPokemonIfBagHasOverThisManyPokemon

Old Setting Was Causing All Possible Evolutions To Be Done If Your Bag Was Fuller Than Specified Amount And Max Interger Was 350 So If Someone Had 1000 Bag Size And Carried 400 Pokemon After Every Action It Would Cause Your Pokemon To Evolve
