### PR TITLE
Refactors TelegramService.cs

### DIFF
--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -159,6 +159,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Data" />
+    <Reference Include="System.Device" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\System.Diagnostics.DiagnosticSource.4.0.0\lib\portable-net45+win8+wpa81\System.Diagnostics.DiagnosticSource.dll</HintPath>
       <Private>True</Private>
@@ -366,6 +367,9 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="Service\TelegramCommand\ICommand.cs" />
+    <Compile Include="Service\TelegramCommand\LocCommand.cs" />
+    <Compile Include="Service\TelegramUtils.cs" />
     <Compile Include="Service\Elevation\BaseElevationService.cs" />
     <Compile Include="Service\Elevation\ElevationService.cs" />
     <Compile Include="Service\Elevation\IElevationService.cs" />
@@ -375,6 +379,8 @@
     <Compile Include="Service\Elevation\GoogleElevationService.cs" />
     <Compile Include="Service\Elevation\MapQuestElevationService.cs" />
     <Compile Include="Service\TelegramCommand\AccountsCommand.cs" />
+    <Compile Include="Service\TelegramCommand\CommandLocation.cs" />
+    <Compile Include="Service\TelegramCommand\CommandMessage.cs" />
     <Compile Include="Service\TelegramCommand\SnipeCommand.cs" />
     <Compile Include="Service\TelegramCommand\RecycleCommand.cs" />
     <Compile Include="Service\TelegramCommand\LogsCommand.cs" />
@@ -384,7 +390,7 @@
     <Compile Include="Service\TelegramCommand\AllCommand.cs" />
     <Compile Include="Service\TelegramCommand\ProfileCommand.cs" />
     <Compile Include="Service\TelegramCommand\PokedexCommand.cs" />
-    <Compile Include="Service\TelegramCommand\ICommand.cs" />
+    <Compile Include="Service\TelegramCommand\ICommandGenerify.cs" />
     <Compile Include="Service\TelegramCommand\HelpCommand.cs" />
     <Compile Include="Service\TelegramCommand\ItemsCommand.cs" />
     <Compile Include="Service\TelegramCommand\StatusCommand.cs" />

--- a/PoGo.NecroBot.Logic/Service/TelegramCommand/AccountsCommand.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramCommand/AccountsCommand.cs
@@ -1,28 +1,26 @@
-﻿using PoGo.NecroBot.Logic.Common;
-using PoGo.NecroBot.Logic.PoGoUtils;
-using PoGo.NecroBot.Logic.State;
+﻿using PoGo.NecroBot.Logic.State;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace PoGo.NecroBot.Logic.Service.TelegramCommand
 {
-    public class AccountsCommand : ICommand
+    public class AccountsCommand : CommandMessage
     {
-        public string Command  =>"/accounts";
-        public string Description => "List all account setup for multiple bot";
-        public bool StopProcess => true;
+        public override string Command => "/accounts";
+        public override string Description => "List all account setup for multiple bot";
+        public override bool StopProcess => true;
 
-        public async Task<bool> OnCommand(ISession session,string cmd, Action<string> Callback)
+        public AccountsCommand(TelegramUtils telegramUtils) : base(telegramUtils)
         {
-            await Task.Delay(0); // Just added to get rid of compiler warning. Remove this if async code is used below.
+        }
 
+        #pragma warning disable CS1998 // added to get rid of compiler warning. Remove this if async code is used below.
+        public override async Task<bool> OnCommand(ISession session, string cmd, Action<string> Callback)
+        {
             string[] messagetext = cmd.Split(' ');
 
             string message = "";
-            if(messagetext[0].ToLower() == Command)
+            if (messagetext[0].ToLower() == Command)
             {
                 if (session.LogicSettings.AllowMultipleBot)
                 {
@@ -41,7 +39,6 @@ namespace PoGo.NecroBot.Logic.Service.TelegramCommand
                 }
                 Callback(message);
                 return true;
-
             }
             return false;
         }

--- a/PoGo.NecroBot.Logic/Service/TelegramCommand/AllCommand.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramCommand/AllCommand.cs
@@ -2,27 +2,29 @@
 using PoGo.NecroBot.Logic.PoGoUtils;
 using PoGo.NecroBot.Logic.State;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace PoGo.NecroBot.Logic.Service.TelegramCommand
 {
-    public class AllCommand : ICommand
+    public class AllCommand : CommandMessage
     {
-        public string Command  =>"/all";
-        public string Description => "<cp/iv> - Shows your Pokemons.";
-        public bool StopProcess => true;
+        public override string Command => "/all";
+        public override string Description => "<cp/iv> - Shows your Pokemons.";
+        public override bool StopProcess => true;
 
-        public async Task<bool> OnCommand(ISession session,string cmd, Action<string> Callback)
+        public AllCommand(TelegramUtils telegramUtils) : base(telegramUtils)
+        {
+        }
+
+        public override async Task<bool> OnCommand(ISession session, string cmd, Action<string> Callback)
         {
             string[] messagetext = cmd.Split(' ');
 
-            if(messagetext[0].ToLower() == Command)
+            if (messagetext[0].ToLower() == Command)
             {
                 var answerTextmessage = "";
-              var myPokemons = await session.Inventory.GetPokemons();
+                var myPokemons = await session.Inventory.GetPokemons();
                 var allMyPokemons = myPokemons.ToList();
                 var allPokemons = await session.Inventory.GetHighestsCp(allMyPokemons.Count);
 
@@ -38,7 +40,7 @@ namespace PoGo.NecroBot.Logic.Service.TelegramCommand
                     }
                     else if (messagetext[1] != "cp")
                     {
-                        answerTextmessage = 
+                        answerTextmessage =
                             session.Translation.GetTranslation(TranslationString.UsageHelp, "/all [cp/iv]");
                     }
                 }

--- a/PoGo.NecroBot.Logic/Service/TelegramCommand/CommandLocation.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramCommand/CommandLocation.cs
@@ -1,0 +1,43 @@
+﻿using PoGo.NecroBot.Logic.Event;
+using PoGo.NecroBot.Logic.State;
+using System;
+using System.Device.Location;
+using System.Threading.Tasks;
+using Telegram.Bot.Types;
+
+namespace PoGo.NecroBot.Logic.Service.TelegramCommand
+{
+    public abstract class CommandLocation : ICommandGenerify<GeoCoordinate>
+    {
+        protected readonly TelegramUtils telegramUtils;
+
+        public CommandLocation(TelegramUtils telegramUtils)
+        {
+            this.telegramUtils = telegramUtils;
+        }
+
+        public abstract string Command { get; }
+        public abstract string Description { get; }
+        public abstract bool StopProcess { get; }
+
+        public abstract Task<bool> OnCommand(ISession session, string cmd, Action<GeoCoordinate> callback);
+
+        public Task<bool> OnCommand(ISession session, string cmd, Message telegramMessage)
+        {
+            Action<GeoCoordinate> callback = async (GeoCoordinate geo) =>
+            {
+                try
+                {
+                    await telegramUtils.SendLocation(geo, telegramMessage.Chat.Id);
+                }
+                catch (Exception ex)
+                {
+                    session.EventDispatcher.Send(new ErrorEvent { Message = ex.Message });
+                    session.EventDispatcher.Send(new ErrorEvent { Message = "Unkown Telegram Error occured. " });
+                }
+            };
+
+            return OnCommand(session, cmd, callback);
+        }
+    }
+}

--- a/PoGo.NecroBot.Logic/Service/TelegramCommand/CommandMessage.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramCommand/CommandMessage.cs
@@ -1,0 +1,42 @@
+﻿using PoGo.NecroBot.Logic.Event;
+using PoGo.NecroBot.Logic.State;
+using System;
+using System.Threading.Tasks;
+using Telegram.Bot.Types;
+
+namespace PoGo.NecroBot.Logic.Service.TelegramCommand
+{
+    public abstract class CommandMessage : ICommandGenerify<string>
+    {
+        protected readonly TelegramUtils telegramUtils;
+
+        public CommandMessage(TelegramUtils telegramUtils)
+        {
+            this.telegramUtils = telegramUtils;
+        }
+
+        public abstract string Command { get; }
+        public abstract string Description { get; }
+        public abstract bool StopProcess { get; }
+
+        public abstract Task<bool> OnCommand(ISession session, string cmd, Action<string> callback);
+
+        public Task<bool> OnCommand(ISession session, string cmd, Message telegramMessage)
+        {
+            Action<string> callback = async (string msg) =>
+            {
+                try
+                {
+                    await telegramUtils.SendMessage(msg, telegramMessage.Chat.Id);
+                }
+                catch (Exception ex)
+                {
+                    session.EventDispatcher.Send(new ErrorEvent { Message = ex.Message });
+                    session.EventDispatcher.Send(new ErrorEvent { Message = "Unkown Telegram Error occured. " });
+                }
+            };
+
+            return OnCommand(session, cmd, callback);
+        }
+    }
+}

--- a/PoGo.NecroBot.Logic/Service/TelegramCommand/ExitCommand.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramCommand/ExitCommand.cs
@@ -1,21 +1,22 @@
 ﻿using PoGo.NecroBot.Logic.State;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace PoGo.NecroBot.Logic.Service.TelegramCommand
 {
-    public class ExitCommand : ICommand
+    public class ExitCommand : CommandMessage
     {
-        public string Command => "/exit";
-        public string Description        =>  "Exit bot";
-        public bool StopProcess => true;
+        public override string Command => "/exit";
+        public override string Description => "Exit bot";
+        public override bool StopProcess => true;
 
-        public async Task<bool> OnCommand(ISession session,string cmd, Action<string> Callback)
+        public ExitCommand(TelegramUtils telegramUtils) : base(telegramUtils)
         {
-            if(cmd.ToLower() == Command)
+        }
+
+        public override async Task<bool> OnCommand(ISession session, string cmd, Action<string> Callback)
+        {
+            if (cmd.ToLower() == Command)
             {
                 Callback("Closing Bot... BYE!");
                 await Task.Delay(5000);

--- a/PoGo.NecroBot.Logic/Service/TelegramCommand/HelpCommand.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramCommand/HelpCommand.cs
@@ -1,35 +1,37 @@
 ﻿using PoGo.NecroBot.Logic.State;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace PoGo.NecroBot.Logic.Service.TelegramCommand
 {
-    public class HelpCommand : ICommand
+    public class HelpCommand : CommandMessage
     {
-        public string Command  => "/help";
-        public string Description => "list all support command";
-        public bool StopProcess => true;
+        public override string Command => "/help";
+        public override string Description => "list all support command";
+        public override bool StopProcess => true;
 
-        public async Task<bool> OnCommand(ISession session,string cmd, Action<string> Callback)
+        public HelpCommand(TelegramUtils telegramUtils) : base(telegramUtils)
         {
-            await Task.Delay(0); // Just added to get rid of compiler warning. Remove this if async code is used below.
+        }
 
+        #pragma warning disable CS1998 // added to get rid of compiler warning. Remove this if async code is used below.
+        public override async Task<bool> OnCommand(ISession session, string cmd, Action<string> Callback)
+        {          
             if (cmd.ToLower() == Command)
             {
-                var type = typeof(ICommand);
-                var types = AppDomain.CurrentDomain.GetAssemblies()
-                    .SelectMany(s => s.GetTypes())
-                    .Where(p => type.IsAssignableFrom(p) && p != type).OrderBy(p=>p.Name);
-                string message = "";
-                foreach (var item in types)
-                {
-                    ICommand telegramCMD =(ICommand) Activator.CreateInstance(item);
-                    message += $"{telegramCMD.Command} - {telegramCMD.Description}\r\n";
-                }
+                var message = "";
+                var iCommandInstances = AppDomain.CurrentDomain.GetAssemblies()
+                    .SelectMany(x => x.GetTypes())
+                    .Where(x => (typeof(ICommand).IsAssignableFrom(x)) && !x.IsInterface && !x.IsAbstract)
+                    .Select(x => (ICommand)Activator.CreateInstance(x, telegramUtils));
 
+                foreach (var instance in iCommandInstances)
+                {
+
+                    message += $"{((ICommand)instance).Command} - {((ICommand)instance).Description}\r\n";
+                }
+                                
                 Callback(message);
                 return true;
 

--- a/PoGo.NecroBot.Logic/Service/TelegramCommand/ICommand.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramCommand/ICommand.cs
@@ -1,9 +1,6 @@
 ﻿using PoGo.NecroBot.Logic.State;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
+using Telegram.Bot.Types;
 
 namespace PoGo.NecroBot.Logic.Service.TelegramCommand
 {
@@ -11,7 +8,7 @@ namespace PoGo.NecroBot.Logic.Service.TelegramCommand
     {
         string Command { get; }
         string Description { get; }
-        bool   StopProcess { get;  }
-        Task<bool> OnCommand(ISession session, string cmd, Action<string> cb);
+        bool StopProcess { get; }
+        Task<bool> OnCommand(ISession session, string cmd, Message telegramMessage);
     }
 }

--- a/PoGo.NecroBot.Logic/Service/TelegramCommand/ICommandGenerify.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramCommand/ICommandGenerify.cs
@@ -1,0 +1,11 @@
+﻿using PoGo.NecroBot.Logic.State;
+using System;
+using System.Threading.Tasks;
+
+namespace PoGo.NecroBot.Logic.Service.TelegramCommand
+{
+    interface ICommandGenerify<T> : ICommand
+    {
+        Task<bool> OnCommand(ISession session, string cmd, Action<T> callback);
+    }
+}

--- a/PoGo.NecroBot.Logic/Service/TelegramCommand/ItemsCommand.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramCommand/ItemsCommand.cs
@@ -2,19 +2,21 @@
 using PoGo.NecroBot.Logic.State;
 using POGOProtos.Inventory.Item;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace PoGo.NecroBot.Logic.Service.TelegramCommand
 {
-    public class ItemsCommand : ICommand
+    public class ItemsCommand : CommandMessage
     {
-        public string Command   =>  "/items";
-        public string Description  =>  "Shows your items.";
-        public bool StopProcess => true;
-        public async Task<bool> OnCommand(ISession session,string cmd, Action<string> Callback)
+        public override string Command   =>  "/items";
+        public override string Description  =>  "Shows your items.";
+        public override bool StopProcess => true;
+        
+        public ItemsCommand(TelegramUtils telegramUtils) : base(telegramUtils)
+        {
+        }
+
+        public override async Task<bool> OnCommand(ISession session,string cmd, Action<string> Callback)
         {
             if(cmd.ToLower() == Command)
             {

--- a/PoGo.NecroBot.Logic/Service/TelegramCommand/LocCommand.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramCommand/LocCommand.cs
@@ -1,0 +1,28 @@
+﻿using PoGo.NecroBot.Logic.State;
+using System;
+using System.Device.Location;
+using System.Threading.Tasks;
+
+namespace PoGo.NecroBot.Logic.Service.TelegramCommand
+{
+    public class LocCommand : CommandLocation
+    {
+        public override string Command => "/loc";
+        public override string Description => "Shows the bots current location";
+        public override bool StopProcess => true;
+
+        public LocCommand(TelegramUtils telegramUtils) : base(telegramUtils)
+        {
+        }
+
+        public override async Task<bool> OnCommand(ISession session, string cmd, Action<GeoCoordinate> Callback)
+        {
+            if (cmd.ToLower() == Command)
+            {
+                Callback(new GeoCoordinate(session.Client.CurrentLatitude, session.Client.CurrentLongitude));
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/PoGo.NecroBot.Logic/Service/TelegramCommand/LogsCommand.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramCommand/LogsCommand.cs
@@ -1,22 +1,21 @@
 ﻿using PoGo.NecroBot.Logic.State;
 using PoGo.NecroBot.Logic.Tasks;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace PoGo.NecroBot.Logic.Service.TelegramCommand
 {
-    public class RecycleCommand : ICommand
+    public class LogsCommand : CommandMessage
     {
-        public string Command  => "/recycle";
-        public string Description => "lets oder bot to recycle items";
-        public bool StopProcess => true;
+        public override string Command  => "/recycle";
+        public override string Description => "lets oder bot to recycle items";
+        public override bool StopProcess => true;
 
-        public async Task<bool> OnCommand(ISession session,string commandText, Action<string> Callback)
+        public LogsCommand(TelegramUtils telegramUtils) : base(telegramUtils)
+        {
+        }
+
+        public override async Task<bool> OnCommand(ISession session,string commandText, Action<string> Callback)
         {
             var cmd = commandText.Split(' ');
 

--- a/PoGo.NecroBot.Logic/Service/TelegramCommand/PokedexCommand.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramCommand/PokedexCommand.cs
@@ -2,22 +2,24 @@
 using PoGo.NecroBot.Logic.State;
 using POGOProtos.Enums;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace PoGo.NecroBot.Logic.Service.TelegramCommand
 {
-    public class PokedexCommand : ICommand
+    public class PokedexCommand : CommandMessage
     {
-        public string Command =>  "/pokedex";
-        public string Description=>  "Shows you Pokedex. ";
-        public bool StopProcess => true;
+        public override string Command =>  "/pokedex";
+        public override string Description =>  "Shows you Pokedex. ";
+        public override bool StopProcess => true;
 
-        public async Task<bool> OnCommand(ISession session,string cmd, Action<string> Callback)
+        public PokedexCommand(TelegramUtils telegramUtils) : base(telegramUtils)
         {
-            await Task.Delay(0); // Just added to get rid of compiler warning. Remove this if async code is used below.
+        }
+
+        #pragma warning disable CS1998 // added to get rid of compiler warning. Remove this if async code is used below.
+        public override async Task<bool> OnCommand(ISession session,string cmd, Action<string> Callback)
+        {
 
             if (cmd.ToLower() == Command)
             {

--- a/PoGo.NecroBot.Logic/Service/TelegramCommand/ProfileCommand.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramCommand/ProfileCommand.cs
@@ -1,22 +1,24 @@
 ﻿using PoGo.NecroBot.Logic.Common;
 using PoGo.NecroBot.Logic.State;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace PoGo.NecroBot.Logic.Service.TelegramCommand
 {
-    public class ProfileCommand : ICommand
+    public class ProfileCommand : CommandMessage
     {
-        public string Command  => "/profile";
-        public string Description=> "Shows your profile. ";
-        public bool StopProcess   => true;
+        public override string Command => "/profile";
+        public override string Description => "Shows your profile. ";
+        public override bool StopProcess => true;
 
-        public async Task<bool> OnCommand(ISession session,string cmd, Action<string> Callback)
+        public ProfileCommand(TelegramUtils telegramUtils) : base(telegramUtils)
         {
-            if(cmd.ToLower() == Command)
+        }
+
+        public override async Task<bool> OnCommand(ISession session, string cmd, Action<string> Callback)
+        {
+            if (cmd.ToLower() == Command)
             {
                 string answerTextmessage = "";
 

--- a/PoGo.NecroBot.Logic/Service/TelegramCommand/RecycleCommand.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramCommand/RecycleCommand.cs
@@ -1,24 +1,24 @@
 ﻿using PoGo.NecroBot.Logic.State;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace PoGo.NecroBot.Logic.Service.TelegramCommand
 {
-    public class LogsCommand : ICommand
+    public class RecycleCommand : CommandMessage
     {
-        public string Command  => "/logs";
-        public string Description => "<n> send last n line in logs file, default 10 if not provide";
-        public bool StopProcess => true;
+        public override string Command  => "/logs";
+        public override string Description => "<n> send last n line in logs file, default 10 if not provide";
+        public override bool StopProcess => true;
 
-        public async Task<bool> OnCommand(ISession session,string commandText, Action<string> Callback)
+        public RecycleCommand(TelegramUtils telegramUtils) : base(telegramUtils)
         {
-            await Task.Delay(0); // Just added to get rid of compiler warning. Remove this if async code is used below.
+        }
 
+        #pragma warning disable CS1998 // added to get rid of compiler warning. Remove this if async code is used below.
+        public override async Task<bool> OnCommand(ISession session,string commandText, Action<string> Callback)
+        {
             var cmd = commandText.Split(' ');
 
             if (cmd[0].ToLower() == Command)

--- a/PoGo.NecroBot.Logic/Service/TelegramCommand/RestartCommand.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramCommand/RestartCommand.cs
@@ -1,21 +1,22 @@
 ﻿using PoGo.NecroBot.Logic.State;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace PoGo.NecroBot.Logic.Service.TelegramCommand
 {
-    public class RestartCommand : ICommand
+    public class RestartCommand : CommandMessage
     {
-        public string Command => "/restart";
-        public string Description        =>  "Restart bot";
-        public bool StopProcess => true;
+        public override string Command => "/restart";
+        public override string Description        =>  "Restart bot";
+        public override bool StopProcess => true;
 
-        public async Task<bool> OnCommand(ISession session,string cmd, Action<string> Callback)
+        public RestartCommand(TelegramUtils telegramUtils) : base(telegramUtils)
+        {
+        }
+
+        public override async Task<bool> OnCommand(ISession session,string cmd, Action<string> Callback)
         {
             if(cmd.ToLower() == Command)
             {

--- a/PoGo.NecroBot.Logic/Service/TelegramCommand/SnipeCommand.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramCommand/SnipeCommand.cs
@@ -2,22 +2,21 @@
 using PoGo.NecroBot.Logic.Tasks;
 using POGOProtos.Enums;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace PoGo.NecroBot.Logic.Service.TelegramCommand
 {
-    public class SnipeCommand : ICommand
+    public class SnipeCommand : CommandMessage
     {
-        public string Command  => "/snipe";
-        public string Description => "add snipe item <pokemon,lat,lng>";
-        public bool StopProcess => true;
+        public override string Command  => "/snipe";
+        public override string Description => "add snipe item <pokemon,lat,lng>";
+        public override bool StopProcess => true;
 
-        public async Task<bool> OnCommand(ISession session,string commandText, Action<string> Callback)
+        public SnipeCommand(TelegramUtils telegramUtils) : base(telegramUtils)
+        {
+        }
+
+        public override async Task<bool> OnCommand(ISession session,string commandText, Action<string> Callback)
         {
             var cmd = commandText.Split(' ');
 

--- a/PoGo.NecroBot.Logic/Service/TelegramCommand/StatusCommand.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramCommand/StatusCommand.cs
@@ -1,22 +1,22 @@
 ﻿using PoGo.NecroBot.Logic.State;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace PoGo.NecroBot.Logic.Service.TelegramCommand
 {
-    public class StatusCommand : ICommand
+    public class StatusCommand : CommandMessage
     {
-        public string Command =>  "/status";
-        public string Description =>  "Shows you the Status of the Bot.";
-        public bool StopProcess => true;
+        public override string Command =>  "/status";
+        public override string Description =>  "Shows you the Status of the Bot.";
+        public override bool StopProcess => true;
 
-        public async Task<bool> OnCommand(ISession session,string cmd, Action<string> Callback)
+        public StatusCommand(TelegramUtils telegramUtils) : base(telegramUtils)
         {
-            await Task.Delay(0); // Just added to get rid of compiler warning. Remove this if async code is used below.
+        }
 
+        #pragma warning disable CS1998 // added to get rid of compiler warning. Remove this if async code is used below.
+        public override async Task<bool> OnCommand(ISession session,string cmd, Action<string> Callback)
+        {
             if (cmd.ToLower() == Command)
             {
                 var answerTextmessage = "";

--- a/PoGo.NecroBot.Logic/Service/TelegramCommand/TopCommand.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramCommand/TopCommand.cs
@@ -4,19 +4,21 @@ using PoGo.NecroBot.Logic.State;
 using POGOProtos.Data;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace PoGo.NecroBot.Logic.Service.TelegramCommand
 {
-    public class TopCommand : ICommand
+    public class TopCommand : CommandMessage
     {
-        public string Command  =>"/top";
-        public string Description => "<cp/iv> <amount> - Shows you top Pokemons. ";
-        public bool StopProcess => true;
+        public override string Command  =>"/top";
+        public override string Description => "<cp/iv> <amount> - Shows you top Pokemons. ";
+        public override bool StopProcess => true;
 
-        public async Task<bool> OnCommand(ISession session,string cmd, Action<string> Callback)
+        public TopCommand(TelegramUtils telegramUtils) : base(telegramUtils)
+        {
+        }
+        
+        public override async Task<bool> OnCommand(ISession session,string cmd, Action<string> Callback)
         {
             string[] messagetext = cmd.Split(' ');
             string answerTextmessage = "";

--- a/PoGo.NecroBot.Logic/Service/TelegramService.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramService.cs
@@ -1,24 +1,18 @@
 ﻿#region using directives
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Reflection;
 using PoGo.NecroBot.Logic.Common;
 using PoGo.NecroBot.Logic.Event;
-using PoGo.NecroBot.Logic.PoGoUtils;
+using PoGo.NecroBot.Logic.Service.TelegramCommand;
 using PoGo.NecroBot.Logic.State;
-using POGOProtos.Data;
-using POGOProtos.Enums;
-using POGOProtos.Inventory.Item;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using Telegram.Bot;
 using Telegram.Bot.Args;
 using Telegram.Bot.Types.Enums;
 using Telegram.Bot.Types.ReplyMarkups;
-using System.Threading.Tasks;
-using PoGo.NecroBot.Logic.Service.TelegramCommand;
-using System.IO;
 
 #endregion
 
@@ -27,10 +21,11 @@ namespace PoGo.NecroBot.Logic.Service
     public class TelegramService
     {
         private DateTime _lastLoginTime;
-        private readonly TelegramBotClient _bot;
+        private readonly TelegramUtils telegramUtils;
         private bool _loggedIn;
         private readonly ISession _session;
-        private List<ICommand> handlers;
+        private readonly TelegramBotClient _bot;
+        private IEnumerable<ICommand> iCommandInstances;
         private long lastChatId = 0;
         private const string LOG_FILE = "config\\telegram.id";
 
@@ -38,19 +33,14 @@ namespace PoGo.NecroBot.Logic.Service
         {
             try
             {
-                var type = typeof(ICommand);
-                var types = AppDomain.CurrentDomain.GetAssemblies()
-                    .SelectMany(s => s.GetTypes())
-                    .Where(p => type.IsAssignableFrom(p) && p != type);
-
-                handlers = new List<ICommand>();
-                foreach (var item in types)
-                {
-                    handlers.Add((ICommand)Activator.CreateInstance(item));
-                }
-
-                _bot = new TelegramBotClient(apiKey);
                 _session = session;
+                _bot = new TelegramBotClient(apiKey);
+                telegramUtils = new TelegramUtils(_bot, _session);
+
+                iCommandInstances = AppDomain.CurrentDomain.GetAssemblies()
+                    .SelectMany(x => x.GetTypes())
+                    .Where(x => (typeof(ICommand).IsAssignableFrom(x)) && !x.IsInterface && !x.IsAbstract)
+                    .Select(x => (ICommand)Activator.CreateInstance(x, telegramUtils));
 
                 var me = _bot.GetMeAsync().Result;
 
@@ -59,26 +49,26 @@ namespace PoGo.NecroBot.Logic.Service
 
                 _session.EventDispatcher.Send(new NoticeEvent { Message = "Using TelegramAPI with " + me.Username });
 
-                if(File.Exists(LOG_FILE))
+                if (File.Exists(LOG_FILE))
                 {
                     var s = File.ReadAllText(LOG_FILE);
-                    if(!string.IsNullOrEmpty(s))
+                    if (!string.IsNullOrEmpty(s))
                     {
                         lastChatId = Convert.ToInt64(s);
-                        SendMessage(_session.Translation.GetTranslation(TranslationString.TelegramBotStarted));
+                        #pragma warning disable 4014 // disables 'await not used warning' - since c'tor is not async by itself we can not use the async statement for method calls
+                        telegramUtils.SendMessage(_session.Translation.GetTranslation(TranslationString.TelegramBotStarted), lastChatId);
                     }
                     else
                     {
                         _session.EventDispatcher.Send(new NoticeEvent() { Message = _session.Translation.GetTranslation(TranslationString.TelegramNeedChatId) });
                     }
-                    
+
                 }
             }
             catch (Exception ex)
             {
                 _session.EventDispatcher.Send(new ErrorEvent { Message = ex.Message });
-
-             _session.EventDispatcher.Send(new ErrorEvent { Message = "Unkown Telegram Error occured. " });
+                _session.EventDispatcher.Send(new ErrorEvent { Message = "Unkown Telegram Error occured. " });
             }
         }
 
@@ -107,15 +97,15 @@ namespace PoGo.NecroBot.Logic.Service
                         _loggedIn = true;
                         _lastLoginTime = DateTime.Now;
                         answerTextmessage += _session.Translation.GetTranslation(TranslationString.LoggedInTelegram);
-                        await SendMessage(message.Chat.Id, answerTextmessage);
+                        await telegramUtils.SendMessage(answerTextmessage, message.Chat.Id);
                         return;
                     }
                     answerTextmessage += _session.Translation.GetTranslation(TranslationString.LoginFailedTelegram);
-                    await SendMessage(message.Chat.Id, answerTextmessage);
+                    await telegramUtils.SendMessage(answerTextmessage, message.Chat.Id);
                     return;
                 }
                 answerTextmessage += _session.Translation.GetTranslation(TranslationString.NotLoggedInTelegram);
-                await SendMessage(message.Chat.Id, answerTextmessage);
+                await telegramUtils.SendMessage(answerTextmessage, message.Chat.Id);
                 return;
             }
             if (_loggedIn)
@@ -124,67 +114,43 @@ namespace PoGo.NecroBot.Logic.Service
                 {
                     _loggedIn = false;
                     answerTextmessage += _session.Translation.GetTranslation(TranslationString.NotLoggedInTelegram);
-                    await SendMessage(message.Chat.Id, answerTextmessage);
+                    await telegramUtils.SendMessage(answerTextmessage, message.Chat.Id);
                     return;
                 }
                 var remainingMins = _lastLoginTime.AddMinutes(5).Subtract(DateTime.Now).Minutes;
                 var remainingSecs = _lastLoginTime.AddMinutes(5).Subtract(DateTime.Now).Seconds;
                 answerTextmessage += _session.Translation.GetTranslation(TranslationString.LoginRemainingTime,
                     remainingMins, remainingSecs);
-                await SendMessage(message.Chat.Id, answerTextmessage);
+                await telegramUtils.SendMessage(answerTextmessage, message.Chat.Id);
                 return;
             }
 
-            if(messagetext[0].ToLower() == "/loc") { 
-                    SendLocation(message.Chat.Id, _session.Client.CurrentLatitude, _session.Client.CurrentLongitude);
-                return;
-            }
             bool handled = false;
-            Action<string> OnMessageCallback = async (string msg) =>
+            foreach (var item in iCommandInstances)
             {
                 try
                 {
-                    await SendMessage(message.Chat.Id, msg);
-                }
-                catch (Exception)
-                {
-                }
-            };
-            foreach (var item in this.handlers)
-            {
-                try
-                {
-                    handled = await item.OnCommand(_session, message.Text, OnMessageCallback);
+                    handled = await item.OnCommand(_session, message.Text, message);
                     if (handled) break;
                 }
                 catch (Exception)
                 {
                 }
-                
+
             }
-            
-            if(!handled)
+
+            if (!handled)
             {
-                HelpCommand helpCMD = new HelpCommand();
-                await helpCMD.OnCommand(_session, helpCMD.Command, OnMessageCallback);
+                HelpCommand helpCMD = new HelpCommand(telegramUtils);
+                await helpCMD.OnCommand(_session, helpCMD.Command, message);
             }
         }
 
-        private async void SendLocation(long chatId, double currentLatitude, double currentLongitude)
-        {
-            await _bot.SendLocationAsync(chatId, (float)currentLatitude, (float)currentLongitude);
-        }
-
+        [Obsolete("SendMessage in TelegramService.cs is deprecated, please use SendMessage.cs TelegramUtils.")]
         public async Task SendMessage(string message)
         {
-            if (string.IsNullOrEmpty(message) || lastChatId ==0) return;
+            if (string.IsNullOrEmpty(message) || lastChatId == 0) return;
             await _bot.SendTextMessageAsync(lastChatId, message, replyMarkup: new ReplyKeyboardHide());
-        }
-
-        private async Task SendMessage(long chatId, string message)
-        {
-            if (string.IsNullOrEmpty(message)) return;
-            await _bot.SendTextMessageAsync(chatId, message, replyMarkup: new ReplyKeyboardHide());
         }
     }
 }

--- a/PoGo.NecroBot.Logic/Service/TelegramUtils.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramUtils.cs
@@ -1,0 +1,56 @@
+﻿using PoGo.NecroBot.Logic.Event;
+using PoGo.NecroBot.Logic.State;
+using System;
+using System.Device.Location;
+using System.Threading.Tasks;
+using Telegram.Bot;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace PoGo.NecroBot.Logic.Service
+{
+    public class TelegramUtils
+    {
+        private readonly TelegramBotClient bot;
+        private readonly ISession session;
+
+        public TelegramUtils(TelegramBotClient bot, ISession session)
+        {
+            this.bot = bot;
+            this.session = session;
+        }
+
+        public async Task SendLocation(GeoCoordinate geo, Message telegramMessage)
+        {
+            await SendLocation(geo, telegramMessage.MessageId);
+        }
+
+        public async Task SendLocation(GeoCoordinate geo, long chatId)
+        {
+            if (chatId == 0)
+            {
+                session.EventDispatcher.Send(new WarnEvent { Message = String.Format("Could not send location to 'Telegram', because given Chat id was '{0}'", 0) });
+            }
+            await bot.SendLocationAsync(chatId, (float)geo.Latitude, (float)geo.Longitude);
+        }
+
+        public async Task SendMessage(string message, Message telegramMessage)
+        {
+            await SendMessage(message, telegramMessage.MessageId);
+        }
+
+        public async Task SendMessage(string message, long chatId)
+        {
+            if (chatId == 0)
+            {
+                session.EventDispatcher.Send(new WarnEvent { Message = String.Format("Could not send message to 'Telegram', because given Chat id was '{0}'", 0) });
+            }
+            else if (string.IsNullOrEmpty(message))
+            {
+                return;
+            }
+
+            await bot.SendTextMessageAsync(chatId, message, replyMarkup: new ReplyKeyboardHide());
+        }
+    }
+}


### PR DESCRIPTION
I wondered that the /loc telegram command was not listed when using the /help command. (And why my german translation (merged a few days ago) for the help message is not localized).

I refactored TelegramService.cs a bit, added an further interface, added some abstract classes bringing default implementations for common Telegram callbacks, modified the current interface and adapted all classes inherting from it... Further information are in the commit message.

Now you have a much better microframework to invoke any kind of (typed) callback - the /loc command is listed properly and i prepared to fix the missing localization of 'Telegram Bot' messages.