### PR TITLE
Change in choosing the next pokestop or gym

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
@@ -227,13 +227,24 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                 // Return the first gym in range.
                 if (gyms.Count() > 0)
+                {
+                    gyms.OrderBy(p => p.GymPoints);
                     return gyms.FirstOrDefault();
+                }
+               
             }
 
             if (forts.Count == 1)
                 return forts.FirstOrDefault();
 
-            return forts.Skip((int)DateTime.Now.Ticks % 2).FirstOrDefault();
+            
+            if (forts.Count < 4)
+                return forts.Skip((int)DateTime.Now.Ticks % 2).FirstOrDefault();
+            else
+            {
+                Random rnd = new Random();
+                return forts.Skip(rnd.Next(0,3)).FirstOrDefault();
+            }
         }
 
         public static async Task SpinPokestopNearBy(ISession session, CancellationToken cancellationToken, FortData destinationFort = null)


### PR DESCRIPTION
I propose a small change in the election of the next pokestop or gym.
In the case of pokestop I added some more randomness in the selection because it happened that the bot could long enough to move the small square brilliant idea. Substitution or suppress instead of one or any pokestop the range from zero to three.
For gym change is choosing a gym is not the nearest of such who has the least points. I think that this will facilitate the rapid acquisition of a number of gyms in less time.
If you do not change by the end of the match it could could be added to the configuration.