### PR TITLE
Allow rename by level token

### DIFF
--- a/PoGo.NecroBot.Logic/Common/UITranslation.cs
+++ b/PoGo.NecroBot.Logic/Common/UITranslation.cs
@@ -44,6 +44,12 @@ namespace PoGo.NecroBot.Logic.Common
 
         #endregion
 
+        #region Pokemon Inventory
+
+        [Description("Export")]
+        public string Export { get; set; }
+
+        #endregion
         #region Popup
         [Description("Latitude")]
         public string Latitude { get; set; }

--- a/PoGo.NecroBot.Logic/Model/Settings/GlobalSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/GlobalSettings.cs
@@ -511,6 +511,10 @@ namespace PoGo.NecroBot.Logic.Model.Settings
                                 settings["PokeStopConfig"]["PokeStopLimitMinutes"] = 1200;
                         }
                         break;
+                    case 8:
+                        string oldTemplate = (string)settings["PokemonConfig"]["RenameTemplate"];
+                        settings["PokemonConfig"]["RenameTemplate"] = oldTemplate.Replace("{0}", "{Name}").Replace("{1}", "{IV}") + "_LV{Level}";
+                        break;
                         // Add more here.
                 }
             }

--- a/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
@@ -145,7 +145,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public bool RenameOnlyAboveIv;
 
         [ExcelConfig(Description = "The template for pokemon rename", Position = 22)]
-        [DefaultValue("{1}_{0}")]
+        [DefaultValue("{Name}_{IV}_Lv{Level}")]
         [MinLength(0)]
         [MaxLength(32)]
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 22)]

--- a/PoGo.NecroBot.Logic/Model/Settings/UpdateConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/UpdateConfig.cs
@@ -10,7 +10,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         {
         }
 
-        public const int CURRENT_SCHEMA_VERSION = 8;
+        public const int CURRENT_SCHEMA_VERSION = 9;
 
         [DefaultValue(CURRENT_SCHEMA_VERSION)]
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 1)]

--- a/PoGo.NecroBot.Logic/Tasks/RenamePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RenamePokemonTask.cs
@@ -28,16 +28,23 @@ namespace PoGo.NecroBot.Logic.Tasks
                 cancellationToken.ThrowIfCancellationRequested();
 
                 var perfection = Math.Round(PokemonInfo.CalculatePokemonPerfection(pokemon));
+                var level = PokemonInfo.GetLevel(pokemon);
                 var pokemonName = session.Translation.GetPokemonTranslation(pokemon.PokemonId);
                 // iv number + templating part + pokemonName <= 12
-                var nameLength = 12 -
-                                 (perfection.ToString(CultureInfo.InvariantCulture).Length +
-                                  session.LogicSettings.RenameTemplate.Length - 6);
+                
+                var newNickname = session.LogicSettings.RenameTemplate;
+                newNickname.Replace("{IV}", Math.Round(perfection, 0).ToString());
+                newNickname.Replace("{Level}", Math.Round(level, 0).ToString());
+
+                var nameLength = 18 - newNickname.Length;
                 if (pokemonName.Length > nameLength)
                 {
                     pokemonName = pokemonName.Substring(0, nameLength);
                 }
-                var newNickname = string.Format(session.LogicSettings.RenameTemplate, pokemonName, perfection);
+
+                newNickname.Replace("{Name}", pokemonName);
+
+
                 var oldNickname = pokemon.Nickname.Length != 0 ? pokemon.Nickname : pokemon.PokemonId.ToString();
 
                 // If "RenameOnlyAboveIv" = true only rename pokemon with IV over "KeepMinIvPercentage"

--- a/PoGo.Necrobot.Window/Controls/PokemonInventory.xaml
+++ b/PoGo.Necrobot.Window/Controls/PokemonInventory.xaml
@@ -15,6 +15,7 @@
         <cv:FavoriteTextConverter x:Key="FavoriteTextConverter"/>
         <cv:AllowTransferCheckConverter x:Key="AllowTransferCheckConverter"/>
         <cv:IVToColorConverter x:Key="IVToColorConverter"    />
+        <cv:I18NConveter x:Key="I18NConveter"/>
         <cv:EnumToNumberConverter x:Key="EnumToNumberConverter"></cv:EnumToNumberConverter>
     </Control.Resources>
     <DockPanel LastChildFill="True">
@@ -22,7 +23,7 @@
             <Button  DockPanel.Dock="Right" Name="btnExport" Click="btnExport_Click" Margin="0,0,40,0" >
                 <StackPanel Orientation="Horizontal">
                     <Image Width="16" Source="https://cdn1.iconfinder.com/data/icons/application-file-formats/128/microsoft-excel-128.png" Cursor="Hand"/>
-                    <TextBlock Text="Export" Margin="10,0,0,0"></TextBlock>
+                    <TextBlock Text="{Binding Source=Export, Converter={StaticResource I18NConveter}}" Margin="10,0,0,0"></TextBlock>
                 </StackPanel>
 
             </Button>


### PR DESCRIPTION
Rename token now changed to {Name}_{IV}_{Level} so they can change order or rename by level since many of them want to rename pokemon by level