### PR TITLE
Resuming the attack

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/UseGymBattleTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseGymBattleTask.cs
@@ -265,7 +265,20 @@ namespace PoGo.NecroBot.Logic.Tasks
             }
 
             if (isFailedToStart && _startBattleCounter > 0)
+            {
+                
                 await Execute(session, cancellationToken, gym, fortInfo);
+            }
+
+            var bAction = battleActions.LastOrDefault();
+            if (bAction != null)
+                if ((bAction.Type == BattleActionType.ActionDefeat) || (bAction.Type == BattleActionType.ActionTimedOut))
+                {
+                    if (battleActions.Exists(p => p.Type == BattleActionType.ActionVictory))
+                    {
+                        await Execute(session, cancellationToken, gym, fortInfo);
+                    }
+                }
 
             if (_startBattleCounter <= 0)
                 _startBattleCounter = 3;


### PR DESCRIPTION
Resuming the attack when the final duel lost or elapsed time to fight but won at least one battle.
As a result, if we are not able to overcome all at once oprońców after defeating at least one wzawiamy fight instead of going to the next Gym. Zdywanie Gyms this process becomes more efficient and faster.
