### PR TITLE
Add ability to rename pokemon from WPF GUI

### DIFF
--- a/PoGo.NecroBot.CLI/ConsoleEventListener.cs
+++ b/PoGo.NecroBot.CLI/ConsoleEventListener.cs
@@ -117,6 +117,19 @@ namespace PoGo.NecroBot.CLI
                 LogLevel.LevelUp);
         }
 
+        private static void HandleEvent(RenamePokemonEvent renamePokemonEvent, ISession session)
+        {
+            Logger.Write(
+                session.Translation.GetTranslation(
+                    TranslationString.PokemonRename,
+                    session.Translation.GetPokemonTranslation(renamePokemonEvent.PokemonId),
+                    renamePokemonEvent.Id,
+                    renamePokemonEvent.OldNickname,
+                    renamePokemonEvent.NewNickname
+                ),
+                LogLevel.Info);
+        }
+
         private static void HandleEvent(ItemRecycledEvent itemRecycledEvent, ISession session)
         {
             Logger.Write(

--- a/PoGo.NecroBot.Logic/Event/RenamePokemonEvent.cs
+++ b/PoGo.NecroBot.Logic/Event/RenamePokemonEvent.cs
@@ -1,0 +1,16 @@
+﻿#region using directives
+
+using POGOProtos.Enums;
+
+#endregion
+
+namespace PoGo.NecroBot.Logic.Event
+{
+    public class RenamePokemonEvent : IEvent
+    {
+        public ulong Id;
+        public PokemonId PokemonId;
+        public string OldNickname;
+        public string NewNickname;
+    }
+}

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -260,6 +260,7 @@
     <Compile Include="Event\Snipe\AutoSnipePokemonAddedEvent.cs" />
     <Compile Include="Event\Snipe\SnipePokemonStarted.cs" />
     <Compile Include="Event\Snipe\SnipePokemonUpdateEvent.cs" />
+    <Compile Include="Event\RenamePokemonEvent.cs" />
     <Compile Include="Event\UI\StatusBarEvent.cs" />
     <Compile Include="Event\UpgradePokemonEvent.cs" />
     <Compile Include="Event\UpdateEvent.cs" />
@@ -487,6 +488,7 @@
     <Compile Include="Tasks\FarmPokestopsGPXTask.cs" />
     <Compile Include="Tasks\FarmPokestopsTask.cs" />
     <Compile Include="Tasks\RecycleItemsTask.cs" />
+    <Compile Include="Tasks\RenameSinglePokemonTask.cs" />
     <Compile Include="Tasks\RenamePokemonTask.cs" />
     <Compile Include="Tasks\SelectBuddyPokemonTask.cs" />
     <Compile Include="Tasks\SetMoveToTargetTask.cs" />

--- a/PoGo.NecroBot.Logic/Tasks/RenamePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RenamePokemonTask.cs
@@ -67,15 +67,12 @@ namespace PoGo.NecroBot.Logic.Tasks
                     {
                         pokemon.Nickname = newNickname;
 
-                        session.EventDispatcher.Send(new NoticeEvent
+                        session.EventDispatcher.Send(new RenamePokemonEvent
                         {
-                            Message = session.Translation.GetTranslation(
-                                TranslationString.PokemonRename,
-                                session.Translation.GetPokemonTranslation(pokemon.PokemonId),
-                                pokemon.Id,
-                                oldNickname,
-                                newNickname
-                            )
+                            Id = pokemon.Id,
+                            PokemonId = pokemon.PokemonId,
+                            OldNickname = oldNickname,
+                            NewNickname = newNickname
                         });
                     }
                     //Delay only if the pokemon was really renamed!

--- a/PoGo.NecroBot.Logic/Tasks/RenameSinglePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RenameSinglePokemonTask.cs
@@ -1,0 +1,53 @@
+﻿#region using directives
+
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using PoGo.NecroBot.Logic.Common;
+using PoGo.NecroBot.Logic.Event;
+using PoGo.NecroBot.Logic.PoGoUtils;
+using PoGo.NecroBot.Logic.State;
+using PoGo.NecroBot.Logic.Utils;
+using POGOProtos.Networking.Responses;
+using System.Text.RegularExpressions;
+using PoGo.NecroBot.Logic.Logging;
+using System.Linq;
+
+#endregion
+
+namespace PoGo.NecroBot.Logic.Tasks
+{
+    public class RenameSinglePokemonTask
+    {
+        public static async Task Execute(ISession session, ulong pokemonId, string newNickname, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            TinyIoC.TinyIoCContainer.Current.Resolve<MultiAccountManager>().ThrowIfSwitchAccountRequested();
+            var pokemon = session.Inventory.GetPokemons().Where(x => x.Id == pokemonId).FirstOrDefault();
+
+            if (pokemon == null || pokemon.Nickname == newNickname)
+                return;
+
+            if (newNickname.Length > 12)
+                newNickname = newNickname.Substring(0, 12);
+
+            var oldNickname = string.IsNullOrEmpty(pokemon.Nickname) ? pokemon.PokemonId.ToString() : pokemon.Nickname;
+
+            var result = await session.Client.Inventory.NicknamePokemon(pokemon.Id, newNickname);
+
+            if (result.Result == NicknamePokemonResponse.Types.Result.Success)
+            {
+                pokemon.Nickname = newNickname;
+
+                session.EventDispatcher.Send(new RenamePokemonEvent
+                {
+                    Id = pokemon.Id,
+                    PokemonId = pokemon.PokemonId,
+                    OldNickname = oldNickname,
+                    NewNickname = newNickname
+                });
+            }
+        }
+    }
+}

--- a/PoGo.Necrobot.Window/MainClientWindow.xaml.UIEvents.cs
+++ b/PoGo.Necrobot.Window/MainClientWindow.xaml.UIEvents.cs
@@ -144,6 +144,10 @@ namespace PoGo.Necrobot.Window
             lblAccount.Content = $"{this.datacontext.UI.PlayerStatus} as : {this.datacontext.UI.PlayerName}";
 
         }
+        public void OnBotEvent(RenamePokemonEvent renamePokemonEvent)
+        {
+            this.datacontext.PokemonList.OnRename(renamePokemonEvent);
+        }
         public void OnBotEvent(TransferPokemonEvent transferedPkm)
         {
             this.datacontext.PokemonList.OnTransfer(transferedPkm);

--- a/PoGo.Necrobot.Window/Model/PokemonDataViewModel.cs
+++ b/PoGo.Necrobot.Window/Model/PokemonDataViewModel.cs
@@ -1,11 +1,12 @@
 ﻿using PoGo.NecroBot.Logic.PoGoUtils;
 using PoGo.NecroBot.Logic.State;
+using PoGo.NecroBot.Logic.Tasks;
 using POGOProtos.Data;
 using POGOProtos.Enums;
-using POGOProtos.Inventory;
 using POGOProtos.Settings.Master;
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace PoGo.Necrobot.Window.Model
 {
@@ -39,7 +40,18 @@ namespace PoGo.Necrobot.Window.Model
 
             set
             {
-                PokemonData.Nickname = value;
+                if (PokemonData.Nickname != value)
+                {
+                    // Fire off the rename
+                    Task.Run(async () =>
+                    {
+                        await RenameSinglePokemonTask.Execute(
+                            this.Session,
+                            PokemonData.Id,
+                            value,
+                            this.Session.CancellationTokenSource.Token);
+                    });
+                }
             }
         }
 

--- a/PoGo.Necrobot.Window/Model/PokemonListModel.cs
+++ b/PoGo.Necrobot.Window/Model/PokemonListModel.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using PoGo.NecroBot.Logic.Event;
-using POGOProtos.Inventory;
-using POGOProtos.Settings.Master;
 using PoGo.NecroBot.Logic.Event.Inventory;
 using PoGo.NecroBot.Logic.State;
 
@@ -128,6 +126,13 @@ namespace PoGo.Necrobot.Window.Model
 
             if (pkm != null)
                 this.Pokemons.Remove(pkm);
+        }
+
+        internal void OnRename(RenamePokemonEvent e)
+        {
+            var pkm = Get(e.Id);
+            pkm.PokemonData.Nickname = e.NewNickname;
+            pkm.RaisePropertyChanged("PokemonName");
         }
 
         internal void OnTransfer(TransferPokemonEvent e)


### PR DESCRIPTION
## Short Description:
Allows you to rename pokemon from the WPF GUI.

## Fixes (provide links to github issues if you can):
Fixes #742 