### PR TITLE
Add caught location to pokemon inventory

### DIFF
--- a/PoGo.NecroBot.Logic/Common/UITranslation.cs
+++ b/PoGo.NecroBot.Logic/Common/UITranslation.cs
@@ -119,10 +119,12 @@ namespace PoGo.NecroBot.Logic.Common
 
         [Description("Level")]
         public string Level { get; set; }
-
-
+        
         [Description("Caught at")]
         public string CaughtTime { get; set; }
+
+        [Description("Location")]
+        public string CaughtLocation { get; set; }
 
         #endregion
         #region Popup

--- a/PoGo.Necrobot.Window/Controls/PokemonInventory.xaml
+++ b/PoGo.Necrobot.Window/Controls/PokemonInventory.xaml
@@ -87,6 +87,8 @@
                 <DataGridTextColumn Binding="{Binding Move2, StringFormat=\{0\}}" Header="{Binding Source=Move2, Converter={StaticResource I18NConveter}}" MinWidth="90" IsReadOnly="True"/>
 
                 <DataGridTextColumn Binding="{Binding CaughtTime, StringFormat=\{0\}}" Header="{Binding Source=CaughtTime, Converter={StaticResource I18NConveter}}" MinWidth="90" IsReadOnly="True"/>
+                <DataGridTextColumn Binding="{Binding CaughtLocation}" Header="{Binding Source=CaughtLocation, Converter={StaticResource I18NConveter}}" MinWidth="90" IsReadOnly="True"/>
+
                 <DataGridTemplateColumn Header="Actions">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>

--- a/PoGo.Necrobot.Window/Model/PokemonDataViewModel.cs
+++ b/PoGo.Necrobot.Window/Model/PokemonDataViewModel.cs
@@ -1,9 +1,12 @@
-﻿using PoGo.NecroBot.Logic.PoGoUtils;
+﻿using Geocoding.Google;
+using Google.Common.Geometry;
+using PoGo.NecroBot.Logic.PoGoUtils;
 using PoGo.NecroBot.Logic.State;
 using PoGo.NecroBot.Logic.Tasks;
 using POGOProtos.Data;
 using POGOProtos.Enums;
 using POGOProtos.Settings.Master;
+using PokemonGo.RocketAPI.Util;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -127,7 +130,54 @@ namespace PoGo.Necrobot.Window.Model
             }
         }
 
-        public DateTime CaughtTime => new DateTime(1970, 1, 1, 0, 0, 0).AddMilliseconds(Convert.ToDouble(pokemonData.CreationTimeMs));
+        public DateTime CaughtTime => TimeUtil.GetDateTimeFromMilliseconds((long)pokemonData.CreationTimeMs).ToLocalTime();
+
+        public string CaughtLocation
+        {
+            get
+            {
+                return ReverseGeoCodeCapturedCellIdToLocation(this.PokemonData.CapturedCellId);
+            }
+        }
+
+        private string ReverseGeoCodeCapturedCellIdToLocation(ulong capturedCellId)
+        {
+            var cellId = new S2CellId(capturedCellId);
+            var latlng = cellId.ToLatLng();
+            string location;
+
+            // Check cache for location.
+            bool success = PokemonListModel.LocationsCache.TryGetValue(this.PokemonData.CapturedCellId, out location);
+            if (success)
+                return location;
+            
+            GoogleGeocoder geocoder = new GoogleGeocoder();
+            var addresses = geocoder.ReverseGeocode(new Geocoding.Location(latlng.LatDegrees, latlng.LngDegrees));
+            GoogleAddress addr = addresses.Where(a => !a.IsPartialMatch).FirstOrDefault();
+            
+            if (addr != null && addr[GoogleAddressType.Country] != null)
+            {
+                if (addr[GoogleAddressType.Locality] != null)
+                    location = $"{addr[GoogleAddressType.Locality].LongName}, {addr[GoogleAddressType.Country].LongName}";
+                else if (addr[GoogleAddressType.AdministrativeAreaLevel1] != null)
+                    location = $"{addr[GoogleAddressType.AdministrativeAreaLevel1].LongName}, {addr[GoogleAddressType.Country].LongName}";
+                else if (addr[GoogleAddressType.AdministrativeAreaLevel2] != null)
+                    location = $"{addr[GoogleAddressType.AdministrativeAreaLevel2].LongName}, {addr[GoogleAddressType.Country].LongName}";
+                else if (addr[GoogleAddressType.AdministrativeAreaLevel3] != null)
+                    location = $"{addr[GoogleAddressType.AdministrativeAreaLevel3].LongName}, {addr[GoogleAddressType.Country].LongName}";
+                else
+                    location = $"{addr[GoogleAddressType.Country].LongName}";
+
+                // Add to cache
+                PokemonListModel.LocationsCache.Add(this.PokemonData.CapturedCellId, location);
+            }
+            else
+            {
+                location = $"{latlng.LatDegrees}, {latlng.LngDegrees}";
+            }
+
+            return location;
+        }
 
         private bool isTransfering;
         public bool IsTransfering

--- a/PoGo.Necrobot.Window/Model/PokemonListModel.cs
+++ b/PoGo.Necrobot.Window/Model/PokemonListModel.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using PoGo.NecroBot.Logic.Event;
 using PoGo.NecroBot.Logic.Event.Inventory;
 using PoGo.NecroBot.Logic.State;
+using Caching;
 
 namespace PoGo.Necrobot.Window.Model
 {
@@ -14,6 +15,9 @@ namespace PoGo.Necrobot.Window.Model
         {
             this.Session = Session;
         }
+
+        // Caches
+        public static LRUCache<ulong, string> LocationsCache = new LRUCache<ulong, string>(capacity: 500);
 
         public ObservableCollection<PokemonDataViewModel> Pokemons { get; set; }
 

--- a/PoGo.Necrobot.Window/PoGo.Necrobot.Window.csproj
+++ b/PoGo.Necrobot.Window/PoGo.Necrobot.Window.csproj
@@ -96,6 +96,10 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Geocoding, Version=3.6.0.0, Culture=neutral, PublicKeyToken=7c714700b88674c7, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\Geocoding.net.3.6.0\lib\net40\Geocoding.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="GeoCoordinate.NetStandard1, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\GeoCoordinate.NetStandard1.1.0.0\lib\netstandard1.0\GeoCoordinate.NetStandard1.dll</HintPath>
       <Private>True</Private>
@@ -115,6 +119,10 @@
     <Reference Include="GrayscaleEffect, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>Effects\GrayscaleEffect.dll</HintPath>
+    </Reference>
+    <Reference Include="LRUCache, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\LRUCache.0.1.0\lib\Net20\LRUCache.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="MahApps.Metro, Version=1.3.0.0, Culture=neutral, PublicKeyToken=f4fb5a3c4d1e5b4f, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\MahApps.Metro.1.3.0\lib\net45\MahApps.Metro.dll</HintPath>

--- a/PoGo.Necrobot.Window/packages.config
+++ b/PoGo.Necrobot.Window/packages.config
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Fody" version="1.29.4" targetFramework="net452" developmentDependency="true" />
+  <package id="Geocoding.net" version="3.6.0" targetFramework="net452" />
   <package id="GeoCoordinate.NetStandard1" version="1.0.0" targetFramework="net452" />
   <package id="GMap.NET.Presentation" version="1.7.5" targetFramework="net452" />
   <package id="Google.Protobuf" version="3.2.0" targetFramework="net452" />
+  <package id="LRUCache" version="0.1.0" targetFramework="net452" />
   <package id="MahApps.Metro" version="1.3.0" targetFramework="net452" />
   <package id="MahApps.Metro.Resources" version="0.6.1.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />


### PR DESCRIPTION
## Short Description:
Display capture location in WPF GUI pokemon inventory.

I'm using a LRU cache to decrease the number of reverse geocoding HTTP calls that we make.  Fortunately the grid view is also smart and only lazily reverse geocodes the items in view, so performance is not too bad.

We can store capture locations in database on the disk if performance is unacceptable.

One more thought @samuraitruong, I have a suspicion that the geo-coding code should not belong in the `PokemonDataViewModel`, but was not sure where the best place is with MVVM.

## Fixes (provide links to github issues if you can):
Fixes #755 