### PR TITLE
Fix bug #790 - Pokestops should change back to the unvisited color when spinnable

### DIFF
--- a/PoGo.NecroBot.Logic/Event/FortUsedEvent.cs
+++ b/PoGo.NecroBot.Logic/Event/FortUsedEvent.cs
@@ -1,4 +1,6 @@
-﻿namespace PoGo.NecroBot.Logic.Event
+﻿using POGOProtos.Map.Fort;
+
+namespace PoGo.NecroBot.Logic.Event
 {
     public class FortUsedEvent : IEvent
     {
@@ -11,5 +13,6 @@
         public double Longitude;
         public double Altitude;
         public string Name;
+        public FortData Fort;
     }
 }

--- a/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
@@ -429,7 +429,8 @@ namespace PoGo.NecroBot.Logic.Tasks
                         Latitude = pokeStop.Latitude,
                         Longitude = pokeStop.Longitude,
                         Altitude = session.Client.CurrentAltitude,
-                        InventoryFull = fortSearch.Result == FortSearchResponse.Types.Result.InventoryFull
+                        InventoryFull = fortSearch.Result == FortSearchResponse.Types.Result.InventoryFull,
+                        Fort = pokeStop
                     });
                     if (fortSearch.Result == FortSearchResponse.Types.Result.Success)
                     {

--- a/PoGo.Necrobot.Window/Controls/MapControl.xaml.cs
+++ b/PoGo.Necrobot.Window/Controls/MapControl.xaml.cs
@@ -117,22 +117,16 @@ namespace PoGo.Necrobot.Window.Controls
 
         private GMapMarker playerMarker;
 
-        internal void MarkFortAsLooted(string id)
+        internal void MarkFortAsLooted(FortData fortData)
         {
-            var marker = allMarkers[id];
-            var fort = this.forts.Where(x => x.Id == id).FirstOrDefault();
+            GMapMarker marker = allMarkers[fortData.Id];
+            var fort = this.forts.Where(x => x.Id == fortData.Id).FirstOrDefault();
             if (fort.Type == FortType.Checkpoint)
             {
-                string fortIcon;
-                if (fort.LureInfo != null)
+                if (marker.Shape is FortMarker)
                 {
-                    fortIcon = "images/VisitedLure.png";
+                    ((FortMarker)marker.Shape).UpdateFortData(fortData);
                 }
-                else
-                {
-                    fortIcon = "images/Visited.png";
-                }
-                marker.Shape = new ImageMarker(null, marker, "", fortIcon);
             }
         }
 
@@ -166,7 +160,8 @@ namespace PoGo.Necrobot.Window.Controls
 
         private void AddPokestopMarker(FortData item)
         {
-            if (!this.forts.Exists(x => x.Id == item.Id))
+            var existingFort = this.forts.FirstOrDefault(x => x.Id == item.Id);
+            if (existingFort == null)
             {
                 this.forts.Add(item);
 
@@ -192,6 +187,15 @@ namespace PoGo.Necrobot.Window.Controls
                     allMarkers.Add(item.Id, m);
                     gmap.Markers.Add(m);
                 });
+            }
+            else
+            {
+                // Update state of fort
+                GMapMarker gmapMarker = allMarkers[item.Id];
+                if (gmapMarker.Shape is FortMarker)
+                {
+                    ((FortMarker)gmapMarker.Shape).UpdateFortData(item);
+                }
             }
         }
 

--- a/PoGo.Necrobot.Window/Controls/MapMarkers/FortMarker.xaml.cs
+++ b/PoGo.Necrobot.Window/Controls/MapMarkers/FortMarker.xaml.cs
@@ -50,6 +50,11 @@ namespace PoGo.Necrobot.Window.Controls.MapMarkers
             this.DataContext = this.fort;
         }
 
+        public void UpdateFortData(FortData item)
+        {
+            this.fort.UpdateFortData(item);
+        }
+
         void CustomMarkerDemo_Loaded(object sender, RoutedEventArgs e)
         {
             if (icon.Source.CanFreeze)

--- a/PoGo.Necrobot.Window/MainClientWindow.xaml.UIEvents.cs
+++ b/PoGo.Necrobot.Window/MainClientWindow.xaml.UIEvents.cs
@@ -159,7 +159,7 @@ namespace PoGo.Necrobot.Window
         public void OnBotEvent(FortUsedEvent ev)
         {
             this.datacontext.Sidebar.AddOrUpdate(new PokestopItemViewModel(ev));
-            this.botMap.MarkFortAsLooted(ev.Id);
+            this.botMap.MarkFortAsLooted(ev.Fort);
         }
         public void OnBotEvent(PokeStopListEvent ev)
         {

--- a/PoGo.Necrobot.Window/Model/FortViewModel.cs
+++ b/PoGo.Necrobot.Window/Model/FortViewModel.cs
@@ -3,10 +3,6 @@ using PoGo.NecroBot.Logic.Utils;
 using POGOProtos.Map.Fort;
 using PokemonGo.RocketAPI.Extensions;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using TinyIoC;
 
 namespace PoGo.Necrobot.Window.Model
@@ -43,12 +39,30 @@ namespace PoGo.Necrobot.Window.Model
                 return fortIcon;
             }
         }
+
         public FortViewModel(FortData data)
         {
             this.Session = TinyIoCContainer.Current.Resolve<ISession>();
             this.fort = data;
             
             UpdateDistance(this.Session.Client.CurrentLatitude, this.Session.Client.CurrentLongitude);
+        }
+
+        public void UpdateFortData(FortData newFort)
+        {
+            var originalFort = this.fort;
+            this.fort = newFort;
+
+            if (IsVisited(newFort) != IsVisited(originalFort) || newFort.LureInfo != originalFort.LureInfo)
+            {
+                // If lure status or visited status has changed, then raise the property.
+                RaisePropertyChanged("FortIcon");
+            }
+        }
+
+        protected bool IsVisited(FortData data)
+        {
+            return fort.CooldownCompleteTimestampMs > DateTime.UtcNow.ToUnixTime();
         }
 
         internal void UpdateDistance(double lat, double lng)


### PR DESCRIPTION
## Short Description:
Pokestops change color when spun, but never reset back to initial state in the WPF map.

This is only a fix for pokestops.  The issue with map pokemon not disappearing when they expire is still not fixed yet.

## Fixes (provide links to github issues if you can):
Fix bug #790 