### PR TITLE
Bug fix #812 - Allow pokemon to be upgraded to more than 2 levels greater than trainer level

### DIFF
--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -729,7 +729,7 @@ namespace PoGo.NecroBot.Logic
             var pokemonLevel = PokemonInfo.GetLevel(pokemon);
 
             // Can't evolve unless pokemon level is lower than trainer.
-            if (pokemonLevel >= playerLevel)
+            if (pokemonLevel >= playerLevel + 2)
                 return false;
 
             int familyCandy = GetCandyCount(pokemon.PokemonId);


### PR DESCRIPTION
## Short Description:
Should allow a level 30 snorlax to upgrade to level 32 if i am trainer level 30.

## Fixes (provide links to github issues if you can):
Fixes bug #812