### PR TITLE
Fix pokestop status not updating on WPF map.

### DIFF
--- a/PoGo.Necrobot.Window/Model/FortViewModel.cs
+++ b/PoGo.Necrobot.Window/Model/FortViewModel.cs
@@ -53,11 +53,7 @@ namespace PoGo.Necrobot.Window.Model
             var originalFort = this.fort;
             this.fort = newFort;
 
-            if (IsVisited(newFort) != IsVisited(originalFort) || newFort.LureInfo != originalFort.LureInfo)
-            {
-                // If lure status or visited status has changed, then raise the property.
-                RaisePropertyChanged("FortIcon");
-            }
+            RaisePropertyChanged("FortIcon");
         }
 
         protected bool IsVisited(FortData data)


### PR DESCRIPTION
## Short Description:
The map is not reflecting the correct state of pokestops. When a pokestop is spun, it still looks like it is not spun in the WPF GUI map.

## Fixes (provide links to github issues if you can):
Fixes bug #835 