### PR TITLE
Add reverse geolocation caching to speed up WPF GUI pokemon inventory

### DIFF
--- a/PoGo.NecroBot.Logic/Model/GeoLocation.cs
+++ b/PoGo.NecroBot.Logic/Model/GeoLocation.cs
@@ -1,0 +1,150 @@
+﻿using Geocoding.Google;
+using Google.Common.Geometry;
+using LiteDB;
+using PoGo.NecroBot.Logic.Utils;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PoGo.NecroBot.Logic.Model
+{
+    public class GeoLocation
+    {
+        private const string DB_NAME = "Cache\\geolocations.db";
+        private static AsyncLock DB_LOCK = new AsyncLock();
+        private static int GEOCODING_MAX_RETRIES = 5;
+        private static int GEOLOCATION_PRECISION = 3;
+
+        [BsonIndex]
+        public string Id { get; set; }
+        public double Latitude { get; set; }
+        public double Longitude { get; set; }
+        public string Country { get; set; }
+        public string Locality { get; set; }    // City/Town
+        public string AdminLevel1 { get; set; } // State
+        public string AdminLevel2 { get; set; } // County
+        public string AdminLevel3 { get; set; } // City/Town
+
+        public GeoLocation()
+        {
+        }
+
+        public GeoLocation(ulong capturedCellId)
+        {
+            var cellId = new S2CellId(capturedCellId);
+            var latlng = cellId.ToLatLng();
+            Init(latlng.LatDegrees, latlng.LngDegrees);
+        }
+
+        public GeoLocation(double latitude, double longitude)
+        {
+            Init(latitude, longitude);
+        }
+
+        private void Init(double latitude, double longitude)
+        {
+            Latitude = Math.Round(latitude, GEOLOCATION_PRECISION);
+            Longitude = Math.Round(longitude, GEOLOCATION_PRECISION);
+
+            Id = GetIdTokenFromLatLng(latitude, longitude);
+        }
+
+        public async Task ReverseGeocode()
+        {
+            GoogleGeocoder geocoder = new GoogleGeocoder();
+            var addresses = await geocoder.ReverseGeocodeAsync(Latitude, Longitude);
+            GoogleAddress addr = addresses.Where(a => !a.IsPartialMatch).FirstOrDefault();
+
+            if (addr != null)
+            {
+                if (addr[GoogleAddressType.Country] != null)
+                    Country = addr[GoogleAddressType.Country].LongName;
+                if (addr[GoogleAddressType.Locality] != null)
+                    Locality = addr[GoogleAddressType.Locality].LongName;
+                if (addr[GoogleAddressType.AdministrativeAreaLevel1] != null)
+                    AdminLevel1 = addr[GoogleAddressType.AdministrativeAreaLevel1].LongName;
+                if (addr[GoogleAddressType.AdministrativeAreaLevel2] != null)
+                    AdminLevel2 = addr[GoogleAddressType.AdministrativeAreaLevel2].LongName;
+                if (addr[GoogleAddressType.AdministrativeAreaLevel3] != null)
+                    AdminLevel3 = addr[GoogleAddressType.AdministrativeAreaLevel3].LongName;
+            }
+        }
+
+        public static string GetIdTokenFromLatLng(double latitude, double longitude)
+        {
+            latitude = Math.Round(latitude, GEOLOCATION_PRECISION);
+            longitude = Math.Round(longitude, GEOLOCATION_PRECISION);
+
+            //return S2CellId.FromLatLng(S2LatLng.FromDegrees(latitude, longitude)).ParentForLevel(15).ToToken();
+            return $"{latitude},{longitude}";
+        }
+
+        public static async Task<GeoLocation> FindOrUpdateInDatabase(ulong capturedCellId)
+        {
+            var cellId = new S2CellId(capturedCellId);
+            var latlng = cellId.ToLatLng();
+            return await FindOrUpdateInDatabase(latlng.LatDegrees, latlng.LngDegrees);
+        }
+
+        public static async Task<GeoLocation> FindOrUpdateInDatabase(double latitude, double longitude)
+        {
+            using (await DB_LOCK.LockAsync())
+            {
+                using (var db = new LiteDatabase(DB_NAME))
+                {
+                    db.GetCollection<GeoLocation>("locations").EnsureIndex(s => s.Id);
+
+                    var locationsCollection = db.GetCollection<GeoLocation>("locations");
+                    var id = GetIdTokenFromLatLng(latitude, longitude);
+                    var geoLocation = locationsCollection.FindOne(x => x.Id == id);
+
+                    if (geoLocation != null)
+                        return geoLocation;
+
+                    geoLocation = new GeoLocation(latitude, longitude);
+
+                    for (var i = 0; i < GEOCODING_MAX_RETRIES; i++)
+                    {
+                        try
+                        {
+                            await geoLocation.ReverseGeocode();
+                            break;
+                        }
+                        catch (Exception)
+                        {
+                            if (i == GEOCODING_MAX_RETRIES - 1)
+                                return null;
+
+                            // Just ignore exception and retry after delay
+                            await Task.Delay(i * 100);
+                        }
+                    }
+
+                    // Before we store it to the database, ensure it must at least have country field set.
+                    if (string.IsNullOrEmpty(geoLocation.Country))
+                        return null;
+
+                    locationsCollection.Insert(geoLocation);
+                    return geoLocation;
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            if (!string.IsNullOrEmpty(Country))
+            {
+                if (!string.IsNullOrEmpty(Locality))
+                    return $"{Locality}, {Country}";
+                if (!string.IsNullOrEmpty(AdminLevel3))
+                    return $"{AdminLevel3}, {Country}";
+                if (!string.IsNullOrEmpty(AdminLevel2))
+                    return $"{AdminLevel2}, {Country}";
+                if (!string.IsNullOrEmpty(AdminLevel1))
+                    return $"{AdminLevel1}, {Country}";
+                return Country;
+            }
+            return $"{Latitude}, {Longitude}";
+        }
+    }
+}

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -106,6 +106,10 @@
       <HintPath>$(SolutionDir)\packages\EPPlus.4.1.0\lib\net40\EPPlus.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Geocoding, Version=3.6.0.0, Culture=neutral, PublicKeyToken=7c714700b88674c7, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\Geocoding.net.3.6.0\lib\net40\Geocoding.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="GeoCoordinate.NetStandard1, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\GeoCoordinate.NetStandard1.1.0.0\lib\netstandard1.0\GeoCoordinate.NetStandard1.dll</HintPath>
       <Private>True</Private>
@@ -314,6 +318,7 @@
     <Compile Include="Logging\LoggingStrings.cs" />
     <Compile Include="Model\BotActions.cs" />
     <Compile Include="Exceptions\ActiveSwitchByPokemonException.cs" />
+    <Compile Include="Model\GeoLocation.cs" />
     <Compile Include="Model\Google\GoogleObjects\Address_Components.cs" />
     <Compile Include="Model\Google\GoogleObjects\Bounds.cs" />
     <Compile Include="Model\Google\GoogleObjects\DirectionsResponse.cs" />
@@ -510,6 +515,7 @@
     <Compile Include="Tasks\UseLuckyEggTask.cs" />
     <Compile Include="Tasks\UseNearbyPokestopsTask.cs" />
     <Compile Include="TinyIoC.cs" />
+    <Compile Include="Utils\AsyncLock.cs" />
     <Compile Include="Utils\DelayingUtils.cs" />
     <Compile Include="Utils\EggWalker.cs" />
     <Compile Include="Utils\ErrorHandler.cs" />

--- a/PoGo.NecroBot.Logic/Utils/AsyncLock.cs
+++ b/PoGo.NecroBot.Logic/Utils/AsyncLock.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Implementation of AsyncLock from http://www.hanselman.com/blog/ComparingTwoTechniquesInNETAsynchronousCoordinationPrimitives.aspx
+/// </summary>
+namespace PoGo.NecroBot.Logic.Utils
+{
+    public sealed class AsyncLock
+    {
+        private readonly SemaphoreSlim m_semaphore = new SemaphoreSlim(1, 1);
+        private readonly Task<IDisposable> m_releaser;
+
+        public AsyncLock()
+        {
+            m_releaser = Task.FromResult((IDisposable)new Releaser(this));
+        }
+
+        public Task<IDisposable> LockAsync()
+        {
+            var wait = m_semaphore.WaitAsync();
+            return wait.IsCompleted ?
+                        m_releaser :
+                        wait.ContinueWith((_, state) => (IDisposable)state,
+                            m_releaser.Result, CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+        }
+
+        private sealed class Releaser : IDisposable
+        {
+            private readonly AsyncLock m_toRelease;
+            internal Releaser(AsyncLock toRelease) { m_toRelease = toRelease; }
+            public void Dispose() { m_toRelease.m_semaphore.Release(); }
+        }
+    }
+}

--- a/PoGo.NecroBot.Logic/packages.config
+++ b/PoGo.NecroBot.Logic/packages.config
@@ -5,6 +5,7 @@
   <package id="CloudFlareUtilities" version="0.2.1-alpha" targetFramework="net452" />
   <package id="EngineIoClientDotNet" version="0.9.22" targetFramework="net452" />
   <package id="EPPlus" version="4.1.0" targetFramework="net452" />
+  <package id="Geocoding.net" version="3.6.0" targetFramework="net452" />
   <package id="GeoCoordinate" version="2.0.1" targetFramework="net452" />
   <package id="GeoCoordinate.NetStandard1" version="1.0.0" targetFramework="net452" />
   <package id="Google.Protobuf" version="3.2.0" targetFramework="net452" />

--- a/PoGo.Necrobot.Window/Model/PokemonDataViewModel.cs
+++ b/PoGo.Necrobot.Window/Model/PokemonDataViewModel.cs
@@ -1,5 +1,4 @@
-﻿using Geocoding.Google;
-using Google.Common.Geometry;
+﻿using PoGo.NecroBot.Logic.Model;
 using PoGo.NecroBot.Logic.PoGoUtils;
 using PoGo.NecroBot.Logic.State;
 using PoGo.NecroBot.Logic.Tasks;
@@ -133,51 +132,33 @@ namespace PoGo.Necrobot.Window.Model
 
         public DateTime CaughtTime => TimeUtil.GetDateTimeFromMilliseconds((long)pokemonData.CreationTimeMs).ToLocalTime();
 
+        private GeoLocation geoLocation;
+        public GeoLocation GeoLocation
+        {
+            get
+            {
+                return geoLocation;
+            }
+
+            set
+            {
+                geoLocation = value;
+                RaisePropertyChanged("CaughtLocation");
+            }
+        }
+
         public string CaughtLocation
         {
             get
             {
-                return ReverseGeoCodeCapturedCellIdToLocation(this.PokemonData.CapturedCellId);
+                if (geoLocation == null)
+                {
+                    // Just return latitude, longitude string
+                    return new GeoLocation(pokemonData.CapturedCellId).ToString();
+                }
+
+                return geoLocation.ToString();
             }
-        }
-
-        private string ReverseGeoCodeCapturedCellIdToLocation(ulong capturedCellId)
-        {
-            var cellId = new S2CellId(capturedCellId);
-            var latlng = cellId.ToLatLng();
-            string location;
-
-            // Check cache for location.
-            bool success = PokemonListModel.LocationsCache.TryGetValue(this.PokemonData.CapturedCellId, out location);
-            if (success)
-                return location;
-            
-            GoogleGeocoder geocoder = new GoogleGeocoder();
-            var addresses = geocoder.ReverseGeocode(new Geocoding.Location(latlng.LatDegrees, latlng.LngDegrees));
-            GoogleAddress addr = addresses.Where(a => !a.IsPartialMatch).FirstOrDefault();
-            
-            if (addr != null && addr[GoogleAddressType.Country] != null)
-            {
-                if (addr[GoogleAddressType.Locality] != null)
-                    location = $"{addr[GoogleAddressType.Locality].LongName}, {addr[GoogleAddressType.Country].LongName}";
-                else if (addr[GoogleAddressType.AdministrativeAreaLevel1] != null)
-                    location = $"{addr[GoogleAddressType.AdministrativeAreaLevel1].LongName}, {addr[GoogleAddressType.Country].LongName}";
-                else if (addr[GoogleAddressType.AdministrativeAreaLevel2] != null)
-                    location = $"{addr[GoogleAddressType.AdministrativeAreaLevel2].LongName}, {addr[GoogleAddressType.Country].LongName}";
-                else if (addr[GoogleAddressType.AdministrativeAreaLevel3] != null)
-                    location = $"{addr[GoogleAddressType.AdministrativeAreaLevel3].LongName}, {addr[GoogleAddressType.Country].LongName}";
-                else
-                    location = $"{addr[GoogleAddressType.Country].LongName}";
-
-                // Add to cache
-                PokemonListModel.LocationsCache.Add(this.PokemonData.CapturedCellId, location);
-            }
-            else
-            {
-                location = $"{latlng.LatDegrees}, {latlng.LngDegrees}";
-            }
-
-            return location;
         }
 
         private bool isTransfering;

--- a/PoGo.Necrobot.Window/Model/PokemonListModel.cs
+++ b/PoGo.Necrobot.Window/Model/PokemonListModel.cs
@@ -8,6 +8,8 @@ using PoGo.NecroBot.Logic.State;
 using Caching;
 using POGOProtos.Inventory;
 using System;
+using System.Threading.Tasks;
+using PoGo.NecroBot.Logic.Model;
 
 namespace PoGo.Necrobot.Window.Model
 {
@@ -68,7 +70,14 @@ namespace PoGo.Necrobot.Window.Model
                 }
                 else
                 {
-                    Pokemons.Add(new PokemonDataViewModel(this.Session, item));
+                    var pokemonDataViewModel = new PokemonDataViewModel(this.Session, item);
+                    Pokemons.Add(pokemonDataViewModel);
+                    Task.Run(async () =>
+                    {
+                        GeoLocation geoLocation = await GeoLocation.FindOrUpdateInDatabase(pokemonDataViewModel.PokemonData.CapturedCellId);
+                        if (geoLocation != null)
+                            pokemonDataViewModel.GeoLocation = geoLocation;
+                    });
                 }
             }
 


### PR DESCRIPTION
## Short Description:
Add reverse geolocation database to speed up lookup of pokemon caught locations.

New geolocation database is a LiteDB file found in Cache\geolocations.db and is shared by all bots when multibotting.

## Fixes (provide links to github issues if you can):
Fixes #815 
Fixes #826