### PR TITLE
(Enchanment) Delays for catch (Issue-732)

### DIFF
--- a/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
@@ -251,5 +251,13 @@ namespace PoGo.NecroBot.Logic.Interfaces.Configuration
         double EvolveMinCP { get;  }
         double EvolveMinLevel { get; }
         int MinLevelForAutoSnipe { get;  }
+
+        bool UseHumanlikeDelays { get; }
+        int CatchSuccessDelay { get; }
+        int CatchErrorDelay { get; }
+        int CatchEscapeDelay { get; }
+        int CatchFleeDelay { get; }
+        int CatchMissedDelay { get; }
+        int BeforeCatchDelay { get; }
     }
 }

--- a/PoGo.NecroBot.Logic/Model/Settings/GlobalSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/GlobalSettings.cs
@@ -186,6 +186,11 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         [NecrobotConfig(SheetName = "UIConfig", Description = "Define all parametter to display data on UI.")]
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Ignore)]
         public GUIConfig UIConfig = new GUIConfig();
+
+        [NecrobotConfig(SheetName = "HumanlikeDelays", Description = "Define the delays for humanlike behaviour when catching pokemon")]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public HumanlikeDelays HumanlikeDelays = new HumanlikeDelays();
+
         public GlobalSettings()
         {
             InitializePropertyDefaultValues(this);

--- a/PoGo.NecroBot.Logic/Model/Settings/HumanlikeDelays.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/HumanlikeDelays.cs
@@ -1,0 +1,53 @@
+﻿using Newtonsoft.Json;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+namespace PoGo.NecroBot.Logic.Model.Settings
+{
+    public class HumanlikeDelays : BaseConfig
+    {
+        public HumanlikeDelays() : base()
+        {
+        }
+
+        [NecrobotConfig(Description = "Should humanlike delays be used", Position = 1)]
+        [DefaultValue(false)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 1)]
+        public bool UseHumanlikeDelays { get; set; }
+
+        [NecrobotConfig(Description = "Set delay time when catch is success", Position = 2)]
+        [DefaultValue(13000)]
+        [Range(0, 999999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 2)]
+        public int CatchSuccessDelay { get; set; }
+
+        [NecrobotConfig(Description = "Set delay time when catch is error", Position = 3)]
+        [DefaultValue(1000)]
+        [Range(0, 999999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 3)]
+        public int CatchErrorDelay { get; set; }
+
+        [NecrobotConfig(Description = "Set delay time when catch excapes", Position = 4)]
+        [DefaultValue(3500)]
+        [Range(0, 999999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 4)]
+        public int CatchEscapeDelay { get; set; }
+
+        [NecrobotConfig(Description = "Set delay time when catch flees", Position = 5)]
+        [DefaultValue(2000)]
+        [Range(0, 999999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 5)]
+        public int CatchFleeDelay { get; set; }
+
+        [NecrobotConfig(Description = "Set delay time when catch is missed", Position = 6)]
+        [DefaultValue(1000)]
+        [Range(0, 999999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 6)]
+        public int CatchMissedDelay { get; set; }
+
+        [NecrobotConfig(Description = "Set delay time for throwing the ball", Position = 7)]
+        [DefaultValue(1500)]
+        [Range(0, 999999)]
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 7)]
+        public int BeforeCatchDelay { get; set; }
+    }
+}

--- a/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
@@ -290,5 +290,13 @@ namespace PoGo.NecroBot.Logic.Model.Settings
 
         public int MinLevelForAutoSnipe => _settings.SnipeConfig.MinLevelForAutoSnipe;
 
+        public bool UseHumanlikeDelays => _settings.HumanlikeDelays.UseHumanlikeDelays;
+        public int CatchSuccessDelay => _settings.HumanlikeDelays.CatchSuccessDelay;
+        public int CatchErrorDelay => _settings.HumanlikeDelays.CatchErrorDelay;
+        public int CatchEscapeDelay => _settings.HumanlikeDelays.CatchEscapeDelay;
+        public int CatchFleeDelay => _settings.HumanlikeDelays.CatchFleeDelay;
+        public int CatchMissedDelay => _settings.HumanlikeDelays.CatchMissedDelay;
+        public int BeforeCatchDelay => _settings.HumanlikeDelays.BeforeCatchDelay;
+
     }
 }

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -363,6 +363,7 @@
     <Compile Include="Model\Settings\GpxConfig.cs" />
     <Compile Include="Model\Settings\GUIConfig.cs" />
     <Compile Include="Model\Settings\GymConfig.cs" />
+    <Compile Include="Model\Settings\HumanlikeDelays.cs" />
     <Compile Include="Model\Settings\HumanWalkSnipeConfig.cs" />
     <Compile Include="Model\Settings\HumanWalkSnipeFilter.cs" />
     <Compile Include="Model\Settings\IPokemonFilter.cs" />

--- a/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
@@ -218,6 +218,11 @@ namespace PoGo.NecroBot.Logic.Tasks
                 // Main CatchPokemon-loop
                 do
                 {
+                    if (session.LogicSettings.UseHumanlikeDelays)
+                    {
+                        DelayingUtils.Delay(session.LogicSettings.BeforeCatchDelay, 0);
+                    }
+
                     if ((session.LogicSettings.MaxPokeballsPerPokemon > 0 &&
                          attemptCounter > session.LogicSettings.MaxPokeballsPerPokemon))
                         break;
@@ -406,7 +411,36 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                     attemptCounter++;
 
-                    DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 0);
+                    // If Humanlike delays are used
+                    if (session.LogicSettings.UseHumanlikeDelays)
+                    {
+                        switch (caughtPokemonResponse.Status)
+                        {
+                            case CatchPokemonResponse.Types.CatchStatus.CatchError:
+                                DelayingUtils.Delay(session.LogicSettings.CatchErrorDelay, 0);
+                                break;
+
+                            case CatchPokemonResponse.Types.CatchStatus.CatchSuccess:
+                                DelayingUtils.Delay(session.LogicSettings.CatchSuccessDelay, 0);
+                                break;
+
+                            case CatchPokemonResponse.Types.CatchStatus.CatchEscape:
+                                DelayingUtils.Delay(session.LogicSettings.CatchEscapeDelay, 0);
+                                break;
+
+                            case CatchPokemonResponse.Types.CatchStatus.CatchFlee:
+                                DelayingUtils.Delay(session.LogicSettings.CatchFleeDelay, 0);
+                                break;
+
+                            case CatchPokemonResponse.Types.CatchStatus.CatchMissed:
+                                DelayingUtils.Delay(session.LogicSettings.CatchMissedDelay, 0);
+                                break;
+
+                            default:
+                                break;
+                        }
+                    }
+                    else DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 0);
                 } while (caughtPokemonResponse.Status == CatchPokemonResponse.Types.CatchStatus.CatchMissed ||
                          caughtPokemonResponse.Status == CatchPokemonResponse.Types.CatchStatus.CatchEscape);
 


### PR DESCRIPTION
This implements https://github.com/Necrobot-Private/NecroBot/issues/732. Added new configuration section HumanlikeDelays, where you can tweak pokemon catching closer to actual client as described in issue.

It is unclear to me that should this get some sort of schema migration or should this be added to schema.