### PR TITLE
Fix bug #1027 - Don't save last position to file if it is greater than MaxTravelDistanceInMeters

### DIFF
--- a/PoGo.NecroBot.Logic/State/LoadSaveState.cs
+++ b/PoGo.NecroBot.Logic/State/LoadSaveState.cs
@@ -92,13 +92,25 @@ namespace PoGo.NecroBot.Logic.State
         private static double lastLng = 0;
         public static void SaveLocationToDisk(ISession session, double lat, double lng, double speed)
         {
-            if (!session.Stats.IsSnipping  && ((lastLat ==0 && lastLng ==0 ) || LocationUtils.CalculateDistanceInMeters(lat, lng, lastLat, lastLng) <1000))
-            {
-                lastLat = lat;
-                lastLng = lng;
-                var coordsPath = Path.Combine(session.LogicSettings.ProfileConfigPath, "LastPos.ini");
-                File.WriteAllText(coordsPath, $"{lat}:{lng}");
-            }
+            if (session.Stats.IsSnipping)
+                return;
+
+            // Make sure new location is valid.
+            if (!LocationUtils.IsValidLocation(lat, lng))
+                return;
+
+            // If last location is valid, make sure distance between last location and new location is less than 1000m.
+            if ((lastLat != 0 || lastLng != 0) && LocationUtils.CalculateDistanceInMeters(lat, lng, lastLat, lastLng) > 1000)
+                return;
+
+            // Don't save new position if it is outside of our max travel distance.
+            if (LocationUtils.CalculateDistanceInMeters(lat, lng, session.Settings.DefaultLatitude, session.Settings.DefaultLongitude) > session.LogicSettings.MaxTravelDistanceInMeters)
+                return;
+            
+            lastLat = lat;
+            lastLng = lng;
+            var coordsPath = Path.Combine(session.LogicSettings.ProfileConfigPath, "LastPos.ini");
+            File.WriteAllText(coordsPath, $"{lat}:{lng}");
         }
 
         public static Tuple<double, double> LoadPositionFromDisk(ISession session)


### PR DESCRIPTION
## Short Description:
Add additional safety check to not save our last position if outside the max travel distance.

## Fixes (provide links to github issues if you can):
Fixes bug #1027 