### PR TITLE
Fix bug #1077 - Fix TransferWeakPokemon transferring favorited pokemon and pokemon in PokemonsNotToTransfer

### DIFF
--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -140,6 +140,58 @@ namespace PoGo.NecroBot.Logic
                 .Where(p => p != null);
         }
 
+        public IEnumerable<PokemonData> GetWeakPokemonToTransfer(
+            IEnumerable<PokemonId> pokemonsNotToTransfer, Dictionary<PokemonId, EvolveFilter> pokemonEvolveFilters,
+            bool keepPokemonsThatCanEvolve = false, bool prioritizeIVoverCp = false
+        )
+        {
+            var session = TinyIoCContainer.Current.Resolve<ISession>();
+            var myPokemon = GetPokemons();
+
+            var pokemonToTransfer = myPokemon.Where(p => !pokemonsNotToTransfer.Contains(p.PokemonId) && CanTransferPokemon(p));
+            try
+            {
+                pokemonToTransfer =
+                    pokemonToTransfer.Where(
+                            p =>
+                            {
+                                var pokemonTransferFilter = session.LogicSettings.PokemonsTransferFilter.GetFilter<TransferFilter>(p.PokemonId);
+
+                                return !pokemonTransferFilter.MovesOperator.BoolFunc(
+                                    pokemonTransferFilter.MovesOperator.ReverseBoolFunc(
+                                        pokemonTransferFilter.MovesOperator.InverseBool(
+                                            pokemonTransferFilter.Moves.Count > 0),
+                                        pokemonTransferFilter.Moves.Any(moveset =>
+                                            pokemonTransferFilter.MovesOperator.ReverseBoolFunc(
+                                                pokemonTransferFilter.MovesOperator.InverseBool(moveset.Count > 0),
+                                                moveset.Intersect(new[] { p.Move1, p.Move2 }).Count() ==
+                                                Math.Max(Math.Min(moveset.Count, 2), 0)))),
+                                    pokemonTransferFilter.KeepMinOperator.BoolFunc(
+                                        p.Cp >= pokemonTransferFilter.KeepMinCp,
+                                        PokemonInfo.CalculatePokemonPerfection(p) >=
+                                        pokemonTransferFilter.KeepMinIvPercentage,
+                                        pokemonTransferFilter.KeepMinOperator.ReverseBoolFunc(
+                                            pokemonTransferFilter.KeepMinOperator.InverseBool(pokemonTransferFilter
+                                                .UseKeepMinLvl),
+                                            PokemonInfo.GetLevel(p) >= pokemonTransferFilter.KeepMinLvl)));
+                            })
+                        .ToList();
+            }
+            catch (ActiveSwitchByRuleException e)
+            {
+                throw e;
+            }
+
+            if (keepPokemonsThatCanEvolve)
+            {
+                var pokemonToEvolve = session.Inventory.GetPokemonToEvolve(session.LogicSettings.PokemonEvolveFilters);
+
+                pokemonToTransfer = pokemonToTransfer.Where(pokemon => !pokemonToEvolve.Any(p => p.Id == pokemon.Id));
+            }
+
+            return pokemonToTransfer.OrderBy(poke => poke.Cp);
+        }
+
         public IEnumerable<PokemonData> GetDuplicatePokemonToTransfer(
             IEnumerable<PokemonId> pokemonsNotToTransfer, Dictionary<PokemonId, EvolveFilter> pokemonEvolveFilters,
             bool keepPokemonsThatCanEvolve = false, bool prioritizeIVoverCp = false

--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -140,7 +140,7 @@ namespace PoGo.NecroBot.Logic
                 .Where(p => p != null);
         }
 
-        public async Task<IEnumerable<PokemonData>> GetDuplicatePokemonToTransfer(
+        public IEnumerable<PokemonData> GetDuplicatePokemonToTransfer(
             IEnumerable<PokemonId> pokemonsNotToTransfer, Dictionary<PokemonId, EvolveFilter> pokemonEvolveFilters,
             bool keepPokemonsThatCanEvolve = false, bool prioritizeIVoverCp = false
         )
@@ -148,10 +148,7 @@ namespace PoGo.NecroBot.Logic
             var session = TinyIoCContainer.Current.Resolve<ISession>();
             var myPokemon = GetPokemons();
 
-            var pokemonToTransfer = myPokemon
-                .Where(p => !pokemonsNotToTransfer.Contains(p.PokemonId) && p.DeployedFortId == string.Empty &&
-                            p.Favorite == 0 && p.BuddyTotalKmWalked == 0)
-                .ToList();
+            var pokemonToTransfer = myPokemon.Where(p => !pokemonsNotToTransfer.Contains(p.PokemonId) && CanTransferPokemon(p));
 
             try
             {

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -449,6 +449,7 @@
     <Compile Include="Strategies\Walk\IWalkStrategy.cs" />
     <Compile Include="Strategies\Walk\MapzenNavigationStrategy.cs" />
     <Compile Include="Strategies\Walk\YoursNavigationStrategy.cs" />
+    <Compile Include="Tasks\BaseTransferPokemonTask.cs" />
     <Compile Include="Tasks\EggsListTask.cs" />
     <Compile Include="Tasks\EvolveSpecificPokemonTask.cs" />
     <Compile Include="Tasks\FavoritePokemonTask.cs" />

--- a/PoGo.NecroBot.Logic/Tasks/BaseTransferPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/BaseTransferPokemonTask.cs
@@ -1,0 +1,86 @@
+﻿using PoGo.NecroBot.Logic.Common;
+using PoGo.NecroBot.Logic.Event;
+using PoGo.NecroBot.Logic.PoGoUtils;
+using PoGo.NecroBot.Logic.State;
+using PoGo.NecroBot.Logic.Utils;
+using POGOProtos.Data;
+using POGOProtos.Networking.Responses;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PoGo.NecroBot.Logic.Tasks
+{
+    public abstract class BaseTransferPokemonTask
+    {
+        public static async Task Execute(ISession session, IEnumerable<PokemonData> pokemonsToTransfer, CancellationToken cancellationToken)
+        {
+            if (pokemonsToTransfer.Count() > 0)
+            {
+                if (session.LogicSettings.UseBulkTransferPokemon)
+                {
+                    int page = pokemonsToTransfer.Count() / session.LogicSettings.BulkTransferSize + 1;
+                    for (int i = 0; i < page; i++)
+                    {
+                        TinyIoC.TinyIoCContainer.Current.Resolve<MultiAccountManager>().ThrowIfSwitchAccountRequested();
+                        var batchTransfer = pokemonsToTransfer.Skip(i * session.LogicSettings.BulkTransferSize).Take(session.LogicSettings.BulkTransferSize);
+                        var t = await session.Client.Inventory.TransferPokemons(batchTransfer.Select(x => x.Id).ToList());
+                        if (t.Result == ReleasePokemonResponse.Types.Result.Success)
+                        {
+                            foreach (var duplicatePokemon in batchTransfer)
+                            {
+                                PrintPokemonInfo(session, duplicatePokemon);
+                            }
+                        }
+                        else session.EventDispatcher.Send(new WarnEvent() { Message = session.Translation.GetTranslation(TranslationString.BulkTransferFailed, pokemonsToTransfer.Count()) });
+                    }
+                }
+                else
+                {
+                    foreach (var pokemon in pokemonsToTransfer)
+                    {
+                        TinyIoC.TinyIoCContainer.Current.Resolve<MultiAccountManager>().ThrowIfSwitchAccountRequested();
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        await session.Client.Inventory.TransferPokemon(pokemon.Id);
+
+                        PrintPokemonInfo(session, pokemon);
+
+                        // Padding the TransferEvent with player-choosen delay before instead of after.
+                        // This is to remedy too quick transfers, often happening within a second of the
+                        // previous action otherwise
+
+                        await DelayingUtils.DelayAsync(session.LogicSettings.TransferActionDelay, 0, cancellationToken);
+                    }
+                }
+            }
+        }
+
+        public static void PrintPokemonInfo(ISession session, PokemonData duplicatePokemon)
+        {
+            var bestPokemonOfType = (session.LogicSettings.PrioritizeIvOverCp
+                                        ? session.Inventory.GetHighestPokemonOfTypeByIv(duplicatePokemon)
+                                        : session.Inventory.GetHighestPokemonOfTypeByCp(duplicatePokemon)) ??
+                                    duplicatePokemon;
+
+            var ev = new TransferPokemonEvent
+            {
+                Id = duplicatePokemon.Id,
+                PokemonId = duplicatePokemon.PokemonId,
+                Perfection = PokemonInfo.CalculatePokemonPerfection(duplicatePokemon),
+                Cp = duplicatePokemon.Cp,
+                BestCp = bestPokemonOfType.Cp,
+                BestPerfection = PokemonInfo.CalculatePokemonPerfection(bestPokemonOfType),
+                Candy = session.Inventory.GetCandyCount(duplicatePokemon.PokemonId)
+            };
+
+            if (session.Inventory.GetCandyFamily(duplicatePokemon.PokemonId) != null)
+            {
+                ev.FamilyId = session.Inventory.GetCandyFamily(duplicatePokemon.PokemonId).FamilyId;
+            }
+
+            session.EventDispatcher.Send(ev);
+        }
+    }
+}

--- a/PoGo.NecroBot.Logic/Tasks/RenamePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RenamePokemonTask.cs
@@ -31,12 +31,11 @@ namespace PoGo.NecroBot.Logic.Tasks
                 session.LogicSettings.RenamePokemonRespectTransferRule)
             {
                 var duplicatePokemons =
-                   await
-                       session.Inventory.GetDuplicatePokemonToTransfer(
-                           session.LogicSettings.PokemonsNotToTransfer,
-                           session.LogicSettings.PokemonEvolveFilters,
-                           session.LogicSettings.KeepPokemonsThatCanEvolve,
-                           session.LogicSettings.PrioritizeIvOverCp);
+                    session.Inventory.GetDuplicatePokemonToTransfer(
+                        session.LogicSettings.PokemonsNotToTransfer,
+                        session.LogicSettings.PokemonEvolveFilters,
+                        session.LogicSettings.KeepPokemonsThatCanEvolve,
+                        session.LogicSettings.PrioritizeIvOverCp);
 
                 pokemons = pokemons.Where(x => !duplicatePokemons.Any(p => p.Id == x.Id));
             }
@@ -46,8 +45,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                 var pokemonsFiltered =
                     pokemons.Where(pokemon => !session.LogicSettings.PokemonsNotToTransfer.Contains(pokemon.PokemonId) &&
-                        pokemon.Favorite == 0 &&
-                        pokemon.DeployedFortId == string.Empty)
+                        session.Inventory.CanTransferPokemon(pokemon))
                         .ToList().OrderBy(poke => poke.Cp);
 
 
@@ -58,8 +56,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                     if ((pokemon.Cp >= session.LogicSettings.KeepMinCp) ||
                         (PokemonInfo.CalculatePokemonPerfection(pokemon) >= session.LogicSettings.KeepMinIvPercentage &&
                          session.LogicSettings.PrioritizeIvOverCp) ||
-                         (PokemonInfo.GetLevel(pokemon) >= session.LogicSettings.KeepMinLvl && session.LogicSettings.UseKeepMinLvl) ||
-                        pokemon.Favorite == 1)
+                         (PokemonInfo.GetLevel(pokemon) >= session.LogicSettings.KeepMinLvl && session.LogicSettings.UseKeepMinLvl))
                         continue;
 
                     weakPokemons.Add(pokemon);

--- a/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
@@ -37,19 +37,14 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             if (session.LogicSettings.AutoFavoritePokemon)
                 await FavoritePokemonTask.Execute(session, cancellationToken);
-
-            var buddy = session.Profile.PlayerData.BuddyPokemon;
-            var duplicatePokemons =
-                await
-                    session.Inventory.GetDuplicatePokemonToTransfer(
-                        session.LogicSettings.PokemonsNotToTransfer,
-                        session.LogicSettings.PokemonEvolveFilters,
-                        session.LogicSettings.KeepPokemonsThatCanEvolve,
-                        session.LogicSettings.PrioritizeIvOverCp);
             
-            if (buddy != null)
-                duplicatePokemons = duplicatePokemons.Where(x => x.Id != buddy.Id);
-
+            var duplicatePokemons =
+                session.Inventory.GetDuplicatePokemonToTransfer(
+                    session.LogicSettings.PokemonsNotToTransfer,
+                    session.LogicSettings.PokemonEvolveFilters,
+                    session.LogicSettings.KeepPokemonsThatCanEvolve,
+                    session.LogicSettings.PrioritizeIvOverCp);
+            
             var orderedPokemon = duplicatePokemons.OrderBy(poke => poke.Cp);
 
             if (orderedPokemon.Count() > 0)

--- a/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
@@ -18,7 +18,7 @@ using POGOProtos.Settings.Master;
 
 namespace PoGo.NecroBot.Logic.Tasks
 {
-    public class TransferDuplicatePokemonTask
+    public class TransferDuplicatePokemonTask : BaseTransferPokemonTask
     {
         public static async Task Execute(ISession session, CancellationToken cancellationToken)
         {
@@ -47,74 +47,10 @@ namespace PoGo.NecroBot.Logic.Tasks
             
             var orderedPokemon = duplicatePokemons.OrderBy(poke => poke.Cp);
 
-            if (orderedPokemon.Count() > 0)
-            {
-                if (session.LogicSettings.UseBulkTransferPokemon)
-                {
-                    int page = orderedPokemon.Count() / session.LogicSettings.BulkTransferSize + 1;
-                    for (int i = 0; i < page; i++)
-                    {
-                        TinyIoC.TinyIoCContainer.Current.Resolve<MultiAccountManager>().ThrowIfSwitchAccountRequested();
-                        var batchTransfer = orderedPokemon.Skip(i * session.LogicSettings.BulkTransferSize).Take(session.LogicSettings.BulkTransferSize);
-                        var t = await session.Client.Inventory.TransferPokemons(batchTransfer.Select(x => x.Id).ToList());
-                        if (t.Result == ReleasePokemonResponse.Types.Result.Success)
-                        {
-                            foreach (var duplicatePokemon in batchTransfer)
-                            {
-                                PrintPokemonInfo(session, duplicatePokemon);
-                            }
-                        }
-                        else session.EventDispatcher.Send(new WarnEvent() { Message = session.Translation.GetTranslation(TranslationString.BulkTransferFailed, orderedPokemon.Count()) });
-                    }
-                }
-                else
-                {
-                    foreach (var duplicatePokemon in orderedPokemon)
-                    {
-                        TinyIoC.TinyIoCContainer.Current.Resolve<MultiAccountManager>().ThrowIfSwitchAccountRequested();
-                        cancellationToken.ThrowIfCancellationRequested();
-
-                        await session.Client.Inventory.TransferPokemon(duplicatePokemon.Id);
-
-                        PrintPokemonInfo(session, duplicatePokemon);
-
-                        // Padding the TransferEvent with player-choosen delay before instead of after.
-                        // This is to remedy too quick transfers, often happening within a second of the
-                        // previous action otherwise
-
-                        await DelayingUtils.DelayAsync(session.LogicSettings.TransferActionDelay, 0, cancellationToken);
-                    }
-                }
-            }
+            await Execute(session, orderedPokemon, cancellationToken);
 
             // Evolve after transfer
             await EvolvePokemonTask.Execute(session, cancellationToken);
-        }
-
-        public static void PrintPokemonInfo(ISession session, PokemonData duplicatePokemon)
-        {
-            var bestPokemonOfType = (session.LogicSettings.PrioritizeIvOverCp
-                                        ? session.Inventory.GetHighestPokemonOfTypeByIv(duplicatePokemon)
-                                        : session.Inventory.GetHighestPokemonOfTypeByCp(duplicatePokemon)) ??
-                                    duplicatePokemon;
-
-            var ev = new TransferPokemonEvent
-            {
-                Id = duplicatePokemon.Id,
-                PokemonId = duplicatePokemon.PokemonId,
-                Perfection = PokemonInfo.CalculatePokemonPerfection(duplicatePokemon),
-                Cp = duplicatePokemon.Cp,
-                BestCp = bestPokemonOfType.Cp,
-                BestPerfection = PokemonInfo.CalculatePokemonPerfection(bestPokemonOfType),
-                Candy = session.Inventory.GetCandyCount(duplicatePokemon.PokemonId)
-            };
-
-            if (session.Inventory.GetCandyFamily(duplicatePokemon.PokemonId) != null)
-            {
-                ev.FamilyId = session.Inventory.GetCandyFamily(duplicatePokemon.PokemonId).FamilyId;
-            }
-
-            session.EventDispatcher.Send(ev);
         }
     }
 }

--- a/PoGo.NecroBot.Logic/Tasks/TransferWeakPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/TransferWeakPokemonTask.cs
@@ -19,108 +19,39 @@ using System;
 
 namespace PoGo.NecroBot.Logic.Tasks
 {
-    public class TransferWeakPokemonTask
+    public class TransferWeakPokemonTask : BaseTransferPokemonTask
     {
         public static async Task Execute(ISession session, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             TinyIoC.TinyIoCContainer.Current.Resolve<MultiAccountManager>().ThrowIfSwitchAccountRequested();
             if (!session.LogicSettings.TransferWeakPokemon) return;
-
-            if (session.LogicSettings.AutoFavoritePokemon)
-                await FavoritePokemonTask.Execute(session, cancellationToken);
-
-            var pokemons = session.Inventory.GetPokemons();
-
             if (session.LogicSettings.UseBulkTransferPokemon)
             {
                 int buff = session.LogicSettings.BulkTransferStogareBuffer;
                 //check for bag, if bag is nearly full, then process bulk transfer.
                 var maxStorage = session.Profile.PlayerData.MaxPokemonStorage;
+                var totalPokemon = session.Inventory.GetPokemons();
                 var totalEggs = session.Inventory.GetEggs();
-                if ((maxStorage - totalEggs.Count() - buff) > pokemons.Count()) return;
+                if ((maxStorage - totalEggs.Count() - buff) > totalPokemon.Count()) return;
             }
 
-            var pokemonsFiltered =
-                pokemons.Where(pokemon => !session.LogicSettings.PokemonsNotToTransfer.Contains(pokemon.PokemonId) &&
-                    session.Inventory.CanTransferPokemon(pokemon));
+            if (session.LogicSettings.AutoFavoritePokemon)
+                await FavoritePokemonTask.Execute(session, cancellationToken);
 
-            if (session.LogicSettings.KeepPokemonsThatCanEvolve)
-            {
-                var pokemonToEvolve = session.Inventory.GetPokemonToEvolve(session.LogicSettings.PokemonEvolveFilters);
+            var weakPokemon =
+                session.Inventory.GetWeakPokemonToTransfer(
+                    session.LogicSettings.PokemonsNotToTransfer,
+                    session.LogicSettings.PokemonEvolveFilters,
+                    session.LogicSettings.KeepPokemonsThatCanEvolve,
+                    session.LogicSettings.PrioritizeIvOverCp);
 
-                pokemonsFiltered = pokemonsFiltered.Where(pokemon => !pokemonToEvolve.Any(p => p.Id == pokemon.Id));
-            }
+            var orderedPokemon = weakPokemon.OrderBy(poke => poke.Cp);
 
-            var orderedPokemon = pokemonsFiltered.OrderBy(poke => poke.Cp);
-            var pokemonToTransfers = new List<PokemonData>();
-            foreach (var pokemon in orderedPokemon)
-            {
-                TinyIoC.TinyIoCContainer.Current.Resolve<MultiAccountManager>().ThrowIfSwitchAccountRequested();
-                cancellationToken.ThrowIfCancellationRequested();
-                if ((pokemon.Cp >= session.LogicSettings.KeepMinCp) ||
-                    (PokemonInfo.CalculatePokemonPerfection(pokemon) >= session.LogicSettings.KeepMinIvPercentage &&
-                     session.LogicSettings.PrioritizeIvOverCp) ||
-                     (PokemonInfo.GetLevel(pokemon) >= session.LogicSettings.KeepMinLvl && session.LogicSettings.UseKeepMinLvl))
-                    continue;
-
-                if (session.LogicSettings.UseBulkTransferPokemon)
-                {
-                    pokemonToTransfers.Add(pokemon);
-                }
-                else
-                {
-                    await session.Client.Inventory.TransferPokemon(pokemon.Id);
-                    PrintTransferedPokemonInfo(session, pokemon);
-
-                    await DelayingUtils.DelayAsync(session.LogicSettings.TransferActionDelay, 0, cancellationToken);
-                }
-            }
-            if (session.LogicSettings.UseBulkTransferPokemon && pokemonToTransfers.Count > 0)
-            {
-                int page = orderedPokemon.Count() / session.LogicSettings.BulkTransferSize + 1;
-                for (int i = 0; i < page; i++)
-                {
-                    var batchTransfer = orderedPokemon.Skip(i * session.LogicSettings.BulkTransferSize).Take(session.LogicSettings.BulkTransferSize);
-                    var t = await session.Client.Inventory.TransferPokemons(batchTransfer.Select(x => x.Id).ToList());
-                    if (t.Result == ReleasePokemonResponse.Types.Result.Success)
-                    {
-                        foreach (var duplicatePokemon in batchTransfer)
-                        {
-                            PrintTransferedPokemonInfo(session, duplicatePokemon);
-                        }
-                    }
-                    else session.EventDispatcher.Send(new WarnEvent() { Message = session.Translation.GetTranslation(TranslationString.BulkTransferFailed, orderedPokemon.Count()) });
-                }
-            }
+            await Execute(session, orderedPokemon, cancellationToken);
 
             // Evolve after transfer.
             await EvolvePokemonTask.Execute(session, cancellationToken);
-        }
-
-        private static void PrintTransferedPokemonInfo(ISession session, PokemonData pokemon)
-        {
-            var bestPokemonOfType = (session.LogicSettings.PrioritizeIvOverCp
-                                        ? session.Inventory.GetHighestPokemonOfTypeByIv(pokemon)
-                                        : session.Inventory.GetHighestPokemonOfTypeByCp(pokemon)) ?? pokemon;
-
-            var ev = new TransferPokemonEvent
-            {
-                Id = pokemon.Id,
-                PokemonId = pokemon.PokemonId,
-                Perfection = PokemonInfo.CalculatePokemonPerfection(pokemon),
-                Cp = pokemon.Cp,
-                BestCp = bestPokemonOfType.Cp,
-                BestPerfection = PokemonInfo.CalculatePokemonPerfection(bestPokemonOfType),
-                Candy = session.Inventory.GetCandyCount(pokemon.PokemonId)
-            };
-
-            if (session.Inventory.GetCandyFamily(pokemon.PokemonId) != null)
-            {
-                ev.FamilyId = session.Inventory.GetCandyFamily(pokemon.PokemonId).FamilyId;
-            }
-
-            session.EventDispatcher.Send(ev);
         }
     }
 }


### PR DESCRIPTION
## Short Description:
If KeepPokemonsThatCanEvolve is true and TransferWeakPokemon is true, there is a bug where weak transfer will ignore the favorited pokemon and pokemon in the PokemonsNotToTransfer list.

TransferWeakPokemon also did not respect the PokemonTransferFilters.

## Fixes (provide links to github issues if you can):
Fixes #1077 