### PR TITLE
Fixes #1104 - Evolutions and transfers should not be coupled together

### DIFF
--- a/PoGo.NecroBot.Logic/State/CatchState.cs
+++ b/PoGo.NecroBot.Logic/State/CatchState.cs
@@ -103,6 +103,14 @@ namespace PoGo.NecroBot.Logic.State
                                 Message = session.Translation.GetTranslation(TranslationString.InvFullTransferManually)
                             });
                         }
+
+                        if (session.LogicSettings.EvolveAllPokemonAboveIv ||
+                            session.LogicSettings.EvolveAllPokemonWithEnoughCandy ||
+                            session.LogicSettings.UseLuckyEggsWhileEvolving ||
+                            session.LogicSettings.KeepPokemonsThatCanEvolve)
+                        {
+                            await EvolvePokemonTask.Execute(session, cancellationToken);
+                        }
                         break;
 
                     default:

--- a/PoGo.NecroBot.Logic/State/FarmState.cs
+++ b/PoGo.NecroBot.Logic/State/FarmState.cs
@@ -24,6 +24,15 @@ namespace PoGo.NecroBot.Logic.State
                     await UseIncubatorsTask.Execute(session, cancellationToken);
                 if (session.LogicSettings.TransferDuplicatePokemon)
                     await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
+                if (session.LogicSettings.TransferWeakPokemon)
+                    await TransferWeakPokemonTask.Execute(session, cancellationToken);
+                if (session.LogicSettings.EvolveAllPokemonAboveIv ||
+                    session.LogicSettings.EvolveAllPokemonWithEnoughCandy ||
+                    session.LogicSettings.UseLuckyEggsWhileEvolving ||
+                    session.LogicSettings.KeepPokemonsThatCanEvolve)
+                {
+                    await EvolvePokemonTask.Execute(session, cancellationToken);
+                }
                 if (session.LogicSettings.UseLuckyEggConstantly)
                     await UseLuckyEggConstantlyTask.Execute(session, cancellationToken);
                 if (session.LogicSettings.UseIncenseConstantly)

--- a/PoGo.NecroBot.Logic/Tasks/CatchIncensePokemonsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchIncensePokemonsTask.cs
@@ -80,6 +80,13 @@ namespace PoGo.NecroBot.Logic.Tasks
                                 await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
                             if (session.LogicSettings.TransferWeakPokemon)
                                 await TransferWeakPokemonTask.Execute(session, cancellationToken);
+                            if (session.LogicSettings.EvolveAllPokemonAboveIv ||
+                                session.LogicSettings.EvolveAllPokemonWithEnoughCandy ||
+                                session.LogicSettings.UseLuckyEggsWhileEvolving ||
+                                session.LogicSettings.KeepPokemonsThatCanEvolve)
+                            {
+                                await EvolvePokemonTask.Execute(session, cancellationToken);
+                            }
                         }
                         else
                             session.EventDispatcher.Send(new WarnEvent

--- a/PoGo.NecroBot.Logic/Tasks/CatchLurePokemonsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchLurePokemonsTask.cs
@@ -95,6 +95,13 @@ namespace PoGo.NecroBot.Logic.Tasks
                             await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
                         if (session.LogicSettings.TransferWeakPokemon)
                             await TransferWeakPokemonTask.Execute(session, cancellationToken);
+                        if (session.LogicSettings.EvolveAllPokemonAboveIv ||
+                            session.LogicSettings.EvolveAllPokemonWithEnoughCandy ||
+                            session.LogicSettings.UseLuckyEggsWhileEvolving ||
+                            session.LogicSettings.KeepPokemonsThatCanEvolve)
+                        {
+                            await EvolvePokemonTask.Execute(session, cancellationToken);
+                        }
                     }
                     else
                         session.EventDispatcher.Send(new WarnEvent

--- a/PoGo.NecroBot.Logic/Tasks/CatchNearbyPokemonsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchNearbyPokemonsTask.cs
@@ -66,8 +66,19 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                 if (encounter.Status == EncounterResponse.Types.Status.PokemonInventoryFull)
                 {
-                    await TransferWeakPokemonTask.Execute(session, cancellationToken);
-                    await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
+                    if (session.LogicSettings.TransferDuplicatePokemon)
+                        await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
+
+                    if (session.LogicSettings.TransferWeakPokemon)
+                        await TransferWeakPokemonTask.Execute(session, cancellationToken);
+
+                    if (session.LogicSettings.EvolveAllPokemonAboveIv ||
+                        session.LogicSettings.EvolveAllPokemonWithEnoughCandy ||
+                        session.LogicSettings.UseLuckyEggsWhileEvolving ||
+                        session.LogicSettings.KeepPokemonsThatCanEvolve)
+                    {
+                        await EvolvePokemonTask.Execute(session, cancellationToken);
+                    }
                 }
             }
 
@@ -154,6 +165,13 @@ namespace PoGo.NecroBot.Logic.Tasks
                             await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
                         if (session.LogicSettings.TransferWeakPokemon)
                             await TransferWeakPokemonTask.Execute(session, cancellationToken);
+                        if (session.LogicSettings.EvolveAllPokemonAboveIv ||
+                            session.LogicSettings.EvolveAllPokemonWithEnoughCandy ||
+                            session.LogicSettings.UseLuckyEggsWhileEvolving ||
+                            session.LogicSettings.KeepPokemonsThatCanEvolve)
+                        {
+                            await EvolvePokemonTask.Execute(session, cancellationToken);
+                        }
                     }
                     else
                         session.EventDispatcher.Send(new WarnEvent

--- a/PoGo.NecroBot.Logic/Tasks/HumanRandomActionTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/HumanRandomActionTask.cs
@@ -34,6 +34,19 @@ namespace PoGo.NecroBot.Logic.Tasks
                         if (session.LogicSettings.TransferDuplicatePokemon)
                             if (ActionRandom.Next(1, 10) > 4)
                                 await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
+                        if (session.LogicSettings.TransferWeakPokemon)
+                            if (ActionRandom.Next(1, 10) > 4)
+                                await TransferWeakPokemonTask.Execute(session, cancellationToken);
+                        if (ActionRandom.Next(1, 10) > 4)
+                        {
+                            if (session.LogicSettings.EvolveAllPokemonAboveIv ||
+                                session.LogicSettings.EvolveAllPokemonWithEnoughCandy ||
+                                session.LogicSettings.UseLuckyEggsWhileEvolving ||
+                                session.LogicSettings.KeepPokemonsThatCanEvolve)
+                            {
+                                await EvolvePokemonTask.Execute(session, cancellationToken);
+                            }
+                        }
                         break;
                     case 3:
                         if (session.LogicSettings.UseLuckyEggConstantly)

--- a/PoGo.NecroBot.Logic/Tasks/HumanWalkSnipeTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/HumanWalkSnipeTask.cs
@@ -252,8 +252,19 @@ namespace PoGo.NecroBot.Logic.Tasks
                         pokemon.IsCatching = false;
                     }
 
-                    await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
-                    await TransferWeakPokemonTask.Execute(session, cancellationToken);
+                    if (session.LogicSettings.TransferDuplicatePokemon)
+                        await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
+
+                    if (session.LogicSettings.TransferWeakPokemon)
+                        await TransferWeakPokemonTask.Execute(session, cancellationToken);
+
+                    if (session.LogicSettings.EvolveAllPokemonAboveIv ||
+                        session.LogicSettings.EvolveAllPokemonWithEnoughCandy ||
+                        session.LogicSettings.UseLuckyEggsWhileEvolving ||
+                        session.LogicSettings.KeepPokemonsThatCanEvolve)
+                    {
+                        await EvolvePokemonTask.Execute(session, cancellationToken);
+                    }
                 }
             } while (pokemon != null && _setting.HumanWalkingSnipeTryCatchEmAll);
 

--- a/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
@@ -334,6 +334,13 @@ namespace PoGo.NecroBot.Logic.Tasks
                         await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
                     if (session.LogicSettings.TransferWeakPokemon)
                         await TransferWeakPokemonTask.Execute(session, cancellationToken);
+                    if (session.LogicSettings.EvolveAllPokemonAboveIv ||
+                        session.LogicSettings.EvolveAllPokemonWithEnoughCandy ||
+                        session.LogicSettings.UseLuckyEggsWhileEvolving ||
+                        session.LogicSettings.KeepPokemonsThatCanEvolve)
+                    {
+                        await EvolvePokemonTask.Execute(session, cancellationToken);
+                    }
                     if (session.LogicSettings.RenamePokemon)
                         await RenamePokemonTask.Execute(session, cancellationToken);
                     if (session.LogicSettings.AutomaticallyLevelUpPokemon)


### PR DESCRIPTION
## Short Description:
Evolutions not running if transfers are disabled.

## Fixes (provide links to github issues if you can):
Fixes #1104 