### PR TITLE
Fix potential encounter out of range during snipe.

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/MSniperServiceTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/MSniperServiceTask.cs
@@ -449,7 +449,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                 try
                 {
                     LocationUtils.UpdatePlayerLocationWithAltitude(session,
-                        new GeoCoordinate(latitude, longitude, session.Client.CurrentAltitude), 0); // Set speed to 0 for random speed.
+                        new GeoCoordinate(pokemon.Latitude, pokemon.Longitude, session.Client.CurrentAltitude), 0); // Set speed to 0 for random speed.
 
                     encounter =
                         session.Client.Encounter.EncounterPokemon(pokemon.EncounterId, pokemon.SpawnPointId).Result;


### PR DESCRIPTION
## Short Description:
During unverified snipe, we may potentially get out of range error during encounter if the coordinates are not precise enough. This may fix that problem.

## Fixes (provide links to github issues if you can):
Fixes #1136