### PR TITLE
Update xp display to be just for current level instead of total.

### DIFF
--- a/PoGo.NecroBot.Logic/Utils/Statistics.cs
+++ b/PoGo.NecroBot.Logic/Utils/Statistics.cs
@@ -176,6 +176,7 @@ namespace PoGo.NecroBot.Logic.Utils
                     HoursUntilLvl = hours,
                     MinutesUntilLevel = minutes,
                     CurrentXp = stat.Experience,
+                    PreviousXp = stat.PrevLevelXp,
                     LevelupXp = stat.NextLevelXp
                 };
             }
@@ -250,6 +251,7 @@ namespace PoGo.NecroBot.Logic.Utils
         public double HoursUntilLvl;
         public int Level;
         public long LevelupXp;
+        public long PreviousXp;
         public double MinutesUntilLevel;
     }
 }

--- a/PoGo.Necrobot.Window/Model/PlayerInfoModel.cs
+++ b/PoGo.Necrobot.Window/Model/PlayerInfoModel.cs
@@ -168,8 +168,8 @@ namespace PoGo.Necrobot.Window.Model
             this.TimeToLevelUp = $"{stat.StatsExport.HoursUntilLvl:00}h :{stat.StatsExport.MinutesUntilLevel:00}m";
             this.Level = stat.StatsExport.Level;
             this.Stardust = stat.TotalStardust;
-            this.Exp = stat.StatsExport.CurrentXp;
-            this.LevelExp = stat.StatsExport.LevelupXp;
+            this.Exp = stat.StatsExport.CurrentXp - stat.StatsExport.PreviousXp;
+            this.LevelExp = stat.StatsExport.LevelupXp - stat.StatsExport.PreviousXp;
             this.PokemonTransfered = stat.TotalPokemonTransferred;
             this.RaisePropertyChanged("TotalPokemonTransferred;");
             this.RaisePropertyChanged("Runtime");


### PR DESCRIPTION
## Short Description:
Changes the xp display to be only for the current level instead of total experience.

## Fixes (provide links to github issues if you can):
Fixes #1133