### PR TITLE
Pokemon To Catch Locally List

### DIFF
--- a/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
@@ -150,6 +150,7 @@ namespace PoGo.NecroBot.Logic.Interfaces.Configuration
         ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter { get; }
 
         ICollection<PokemonId> PokemonsToLevelUp { get; }
+        CatchSettings PokemonToCatchLocally { get; }
 
         NotificationConfig NotificationConfig { get; }
         ICollection<PokemonId> PokemonsNotToTransfer { get; }

--- a/PoGo.NecroBot.Logic/Model/Settings/CatchSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/CatchSettings.cs
@@ -27,13 +27,6 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         {
             return new CatchSettings
             {
-                Locations = new List<Location>
-                {
-                    new Location(38.55680748646112, -121.2383794784546), //Dratini Spot
-                    new Location(-33.85901900, 151.21309800), //Magikarp Spot
-                    new Location(47.5014969, -122.0959568), //Eevee Spot
-                    new Location(51.5025343, -0.2055027) //Charmender Spot
-                },
                 Pokemon = new List<PokemonId>
                 {
                     PokemonId.Venusaur,

--- a/PoGo.NecroBot.Logic/Model/Settings/CatchSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/CatchSettings.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using POGOProtos.Enums;
+
+namespace PoGo.NecroBot.Logic.Model.Settings
+{
+    [JsonObject(Title = "Catch Settings", Description = "", ItemRequired = Required.DisallowNull)]
+    public class CatchSettings
+    {
+        public CatchSettings()
+        {
+        }
+
+        public CatchSettings(List<Location> locations, List<PokemonId> pokemon)
+        {
+            Locations = locations;
+            Pokemon = pokemon;
+        }
+
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Ignore, Order = 1)]
+        public List<Location> Locations = new List<Location>();
+
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Ignore, Order = 2)]
+        public List<PokemonId> Pokemon = new List<PokemonId>();
+
+        internal static CatchSettings Default()
+        {
+            return new CatchSettings
+            {
+                Locations = new List<Location>
+                {
+                    new Location(38.55680748646112, -121.2383794784546), //Dratini Spot
+                    new Location(-33.85901900, 151.21309800), //Magikarp Spot
+                    new Location(47.5014969, -122.0959568), //Eevee Spot
+                    new Location(51.5025343, -0.2055027) //Charmender Spot
+                },
+                Pokemon = new List<PokemonId>
+                {
+                    PokemonId.Venusaur,
+                    PokemonId.Charizard,
+                    PokemonId.Blastoise,
+                    PokemonId.Beedrill,
+                    PokemonId.Raichu,
+                    PokemonId.Sandslash,
+                    PokemonId.Nidoking,
+                    PokemonId.Nidoqueen,
+                    PokemonId.Clefable,
+                    PokemonId.Ninetales,
+                    PokemonId.Golbat,
+                    PokemonId.Vileplume,
+                    PokemonId.Golduck,
+                    PokemonId.Primeape,
+                    PokemonId.Arcanine,
+                    PokemonId.Poliwrath,
+                    PokemonId.Alakazam,
+                    PokemonId.Machamp,
+                    PokemonId.Golem,
+                    PokemonId.Rapidash,
+                    PokemonId.Slowbro,
+                    PokemonId.Farfetchd,
+                    PokemonId.Muk,
+                    PokemonId.Cloyster,
+                    PokemonId.Gengar,
+                    PokemonId.Exeggutor,
+                    PokemonId.Marowak,
+                    PokemonId.Hitmonchan,
+                    PokemonId.Lickitung,
+                    PokemonId.Rhydon,
+                    PokemonId.Chansey,
+                    PokemonId.Kangaskhan,
+                    PokemonId.Starmie,
+                    PokemonId.MrMime,
+                    PokemonId.Scyther,
+                    PokemonId.Magmar,
+                    PokemonId.Electabuzz,
+                    PokemonId.Jynx,
+                    PokemonId.Gyarados,
+                    PokemonId.Lapras,
+                    PokemonId.Ditto,
+                    PokemonId.Vaporeon,
+                    PokemonId.Jolteon,
+                    PokemonId.Flareon,
+                    PokemonId.Porygon,
+                    PokemonId.Kabutops,
+                    PokemonId.Aerodactyl,
+                    PokemonId.Snorlax,
+                    PokemonId.Articuno,
+                    PokemonId.Zapdos,
+                    PokemonId.Moltres,
+                    PokemonId.Dragonite,
+                    PokemonId.Mewtwo,
+                    PokemonId.Mew
+                }
+            };
+        }
+    }
+}

--- a/PoGo.NecroBot.Logic/Model/Settings/CatchSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/CatchSettings.cs
@@ -13,12 +13,8 @@ namespace PoGo.NecroBot.Logic.Model.Settings
 
         public CatchSettings(List<Location> locations, List<PokemonId> pokemon)
         {
-            Locations = locations;
             Pokemon = pokemon;
         }
-
-        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Ignore, Order = 1)]
-        public List<Location> Locations = new List<Location>();
 
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Ignore, Order = 2)]
         public List<PokemonId> Pokemon = new List<PokemonId>();

--- a/PoGo.NecroBot.Logic/Model/Settings/GlobalSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/GlobalSettings.cs
@@ -123,6 +123,9 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public List<PokemonId> PokemonsNotToTransfer = TransferConfig.PokemonsNotToTransferDefault();
 
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public CatchSettings PokemonToCatchLocally = CatchSettings.Default();
+
+        [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Ignore)]
         public List<PokemonId> PokemonsToLevelUp = LevelUpConfig.PokemonsToLevelUpDefault();
 
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Ignore)]

--- a/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
@@ -151,6 +151,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public bool UseNearActionRandom => _settings.PlayerConfig.UseNearActionRandom;
         public bool UsePokemonToNotCatchFilter => _settings.PokemonConfig.UsePokemonToNotCatchFilter;
         public bool UsePokemonSniperFilterOnly => _settings.PokemonConfig.UsePokemonSniperFilterOnly;
+        public CatchSettings PokemonToCatchLocally => _settings.PokemonToCatchLocally;
         public int KeepMinDuplicatePokemon => _settings.PokemonConfig.KeepMinDuplicatePokemon;
         public bool PrioritizeIvOverCp => _settings.PokemonConfig.PrioritizeIvOverCp;
         public int MaxTravelDistanceInMeters => GenRandom(_settings.LocationConfig.MaxTravelDistanceInMeters);

--- a/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
@@ -353,7 +353,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 55)]
         public bool UsePokemonToNotCatchFilter { get; set; }
 
-        [NecrobotConfig(Description = "UsePokemonSniperFilterOnly", Position = 56)]
+        [NecrobotConfig(Description = "UsePokemonToCatchLocallyListOnly", Position = 56)]
         [DefaultValue(false)]
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 56)]
         public bool UsePokemonSniperFilterOnly { get; set; }

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -376,6 +376,7 @@
     <Compile Include="Model\Settings\ItemRecycleConfig.cs" />
     <Compile Include="Model\Settings\SnipeConfig.cs" />
     <Compile Include="Model\Settings\EvolveFilter.cs" />
+    <Compile Include="Model\Settings\CatchSettings.cs" />
     <Compile Include="Model\Settings\SoftBanConfig.cs" />
     <Compile Include="Model\Settings\TelegramConfig.cs" />
     <Compile Include="Model\Settings\TransferConfig.cs" />

--- a/PoGo.NecroBot.Logic/Tasks/CatchIncensePokemonsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchIncensePokemonsTask.cs
@@ -52,7 +52,8 @@ namespace PoGo.NecroBot.Logic.Tasks
                 if (session.Cache.Get(incensePokemon.EncounterId.ToString()) != null)
                     return; //pokemon been ignore before
 
-                if ((session.LogicSettings.UsePokemonToNotCatchFilter && session.LogicSettings.PokemonsNotToCatch.Contains(pokemon.PokemonId)))
+                if ((session.LogicSettings.UsePokemonSniperFilterOnly && !session.LogicSettings.PokemonToCatchLocally.Pokemon.Contains(pokemon.PokemonId))
+                    || (session.LogicSettings.UsePokemonToNotCatchFilter && session.LogicSettings.PokemonsNotToCatch.Contains(pokemon.PokemonId)))
                 {
                     Logger.Write(session.Translation.GetTranslation(TranslationString.PokemonIgnoreFilter,
                         session.Translation.GetPokemonTranslation(pokemon.PokemonId)));

--- a/PoGo.NecroBot.Logic/Tasks/CatchLurePokemonsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchLurePokemonsTask.cs
@@ -50,7 +50,9 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             var pokemonId = currentFortData.LureInfo.ActivePokemonId;
 
-            if ((session.LogicSettings.UsePokemonToNotCatchFilter &&
+            if ((session.LogicSettings.UsePokemonSniperFilterOnly &&
+                 !session.LogicSettings.PokemonToCatchLocally.Pokemon.Contains(pokemonId)) ||
+                (session.LogicSettings.UsePokemonToNotCatchFilter &&
                  session.LogicSettings.PokemonsNotToCatch.Contains(pokemonId)))
             {
                 session.EventDispatcher.Send(new NoticeEvent

--- a/PoGo.NecroBot.Logic/Tasks/CatchNearbyPokemonsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchNearbyPokemonsTask.cs
@@ -136,7 +136,9 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                 if (session.CatchBlockTime > DateTime.Now) return;
 
-                if ((session.LogicSettings.UsePokemonToNotCatchFilter &&
+                if ((session.LogicSettings.UsePokemonSniperFilterOnly &&
+                     !session.LogicSettings.PokemonToCatchLocally.Pokemon.Contains(pokemon.PokemonId)) ||
+                    (session.LogicSettings.UsePokemonToNotCatchFilter &&
                      session.LogicSettings.PokemonsNotToCatch.Contains(pokemon.PokemonId)))
                 {
                     Logger.Write(session.Translation.GetTranslation(TranslationString.PokemonSkipped,

--- a/PoGo.NecroBot.Logic/Tasks/HumanWalkSnipeTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/HumanWalkSnipeTask.cs
@@ -511,7 +511,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                         continue;
                     }
                     //check if pokemon in the snip list
-                    if (!pokemonToBeSnipedIds.ContainsKey(item.PokemonId)) continue;
+                    if (!pokemonToBeCaughtLocallyIds.ContainsKey(item.PokemonId)) continue;
 
                     count++;
                     var snipeSetting = _setting.HumanWalkSnipeFilters.FirstOrDefault(x => x.Key == item.PokemonId);
@@ -672,7 +672,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             };
 
             //in some case, we caught the pokemon before data refresh, we need add a fake pokemon to list to avoid it add back and waste time 
-            if (!exist && pokemonToBeSnipedIds.ContainsKey(id))
+            if (!exist && pokemonToBeCaughtLocallyIds.ContainsKey(id))
             {
                 var pokemonInfo = new SnipePokemonInfo()
                 {

--- a/PoGo.NecroBot.Logic/Tasks/HumanWalkSnipeTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/HumanWalkSnipeTask.cs
@@ -54,7 +54,7 @@ namespace PoGo.NecroBot.Logic.Tasks
         private static ISession _session;
         private static ILogicSettings _setting;
         private static int pokestopCount = 0;
-        private static ConcurrentDictionary<PokemonId, PokemonId> pokemonToBeSnipedIds = new ConcurrentDictionary<PokemonId, PokemonId>();
+        private static ConcurrentDictionary<PokemonId, PokemonId> pokemonToBeCaughtLocallyIds = new ConcurrentDictionary<PokemonId, PokemonId>();
         static bool prioritySnipeFlag = false;
         private static DateTime lastUpdated = DateTime.Now.AddMinutes(-10);
 
@@ -118,7 +118,7 @@ namespace PoGo.NecroBot.Logic.Tasks
         {
             _session = session;
             _setting = _session.LogicSettings;
-            pokemonToBeSnipedIds = new ConcurrentDictionary<PokemonId, PokemonId>();
+            pokemonToBeCaughtLocallyIds = new ConcurrentDictionary<PokemonId, PokemonId>();
 
             if (_setting.HumanWalkingSnipeUseSnipePokemonList)
             {
@@ -129,10 +129,10 @@ namespace PoGo.NecroBot.Logic.Tasks
             }
 
             foreach (var pokemonId in _setting.HumanWalkSnipeFilters
-                .Where(x => !pokemonToBeSnipedIds.ContainsKey(x.Key))
+                .Where(x => !pokemonToBeCaughtLocallyIds.ContainsKey(x.Key))
                 .Select(x => x.Key))
             {
-                pokemonToBeSnipedIds[pokemonId] = pokemonId;
+                pokemonToBeCaughtLocallyIds[pokemonId] = pokemonId;
             }
             //this will combine with pokemon snipe filter
         }

--- a/PoGo.NecroBot.Logic/Tasks/HumanWalkSnipeTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/HumanWalkSnipeTask.cs
@@ -122,11 +122,10 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             if (_setting.HumanWalkingSnipeUseSnipePokemonList)
             {
-                //get data from snipe filter instead
-                //foreach (var pokemonId in _setting.PokemonToSnipe.Pokemon)
-                //{
-                //    pokemonToBeSnipedIds[pokemonId] = pokemonId;
-                //}
+                foreach (var pokemonId in _setting.PokemonToCatchLocally.Pokemon)
+                {
+                    pokemonToBeCaughtLocallyIds[pokemonId] = pokemonId;
+                }
             }
 
             foreach (var pokemonId in _setting.HumanWalkSnipeFilters


### PR DESCRIPTION
This Way People Can Turn On And Off A List Of Pokemon They Want To Catch Locally But They Can Still Snipe The Pokemon That They Want Or AutoSnipe Pokemon That Meet There Snipe Requirements Much More Efficient Than Using PokemonToIgnore List And Can Be Easily Turned On And Off. Closes #1153 Request. Please Double Check But Worked GREAT Locally 