### PR TITLE
[Asthetics] Code Organization Fixes + Titles No Longer Caps

### DIFF
--- a/PoGo.Necrobot.Window/FilterSetting.xaml
+++ b/PoGo.Necrobot.Window/FilterSetting.xaml
@@ -18,6 +18,17 @@
         MinWidth="800"
         WindowTransitionsEnabled="False"
         WindowStartupLocation="CenterScreen" Initialized="MetroWindow_Initialized" >
+    <Controls:MetroWindow.TitleTemplate>
+        <DataTemplate>
+            <TextBlock x:Name="TitleText"
+                       Text="Filter Config"
+                       TextTrimming="CharacterEllipsis"
+                       VerticalAlignment="Center"
+                       Margin="7, 0, 0, 0"
+                       FontWeight="Normal"
+                       FontFamily="pack://application:,,,/Resources/#Lato-light"/>
+        </DataTemplate>
+    </Controls:MetroWindow.TitleTemplate>
     <Control.Resources>
         <cv:PokemonIdToImageConverter x:Key="PokemonIdToImageConverter" />
         <cv:InverseBooleanConverter x:Key="InverseBooleanConverter" />

--- a/PoGo.Necrobot.Window/MainClientWindow.xaml
+++ b/PoGo.Necrobot.Window/MainClientWindow.xaml
@@ -16,6 +16,17 @@
                       WindowTransitionsEnabled="False"
                       WindowStartupLocation="CenterScreen" 
                       Loaded="MetroWindow_Loaded" Initialized="MetroWindow_Initialized">
+    <Controls:MetroWindow.TitleTemplate>
+        <DataTemplate>
+            <TextBlock x:Name="TitleText"
+                       Text="Necrobot 2 - Window GUI"
+                       TextTrimming="CharacterEllipsis"
+                       VerticalAlignment="Center"
+                       Margin="7, 0, 0, 0"
+                       FontWeight="Normal"
+                       FontFamily="pack://application:,,,/Resources/#Lato-light"/>
+        </DataTemplate>
+    </Controls:MetroWindow.TitleTemplate>
     <Control.Resources>
         <c:I18NConveter x:Key="I18NConveter"/>
         <c:InverseBooleanConverter x:Key="InverseBooleanConverter"/>

--- a/PoGo.Necrobot.Window/PokedexWindow.xaml
+++ b/PoGo.Necrobot.Window/PokedexWindow.xaml
@@ -1,6 +1,6 @@
 ﻿<Controls:MetroWindow x:Class="PoGo.Necrobot.Window.PokedexWindow"
                       xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
-	                  xmlns:Behaviours="clr-namespace:MahApps.Metro.Behaviours;assembly=MahApps.Metro"
+	              xmlns:Behaviours="clr-namespace:MahApps.Metro.Behaviours;assembly=MahApps.Metro"
                       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                       xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"

--- a/PoGo.Necrobot.Window/PokedexWindow.xaml
+++ b/PoGo.Necrobot.Window/PokedexWindow.xaml
@@ -6,7 +6,7 @@
                       xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
                       xmlns:c="clr-namespace:PoGo.Necrobot.Window.Converters"
                       xmlns:effect="clr-namespace:GrayscaleEffect;assembly=GrayscaleEffect"
-                      Title="Necrobot 2 - POKEDEX"
+                      Title="Necrobot 2 - PokeDex"
                       Height="768"
                       Width="1366" 
                       BorderThickness="0" 
@@ -15,9 +15,19 @@
                       Initialized="MetroWindow_Initialized"
                       Loaded="MetroWindow_Loaded"
                       WindowTransitionsEnabled="False"
-                      WindowStartupLocation="CenterScreen" Icon="Ico.ico"
-                      >
-
+                      WindowStartupLocation="CenterScreen" Icon="Ico.ico" >
+    <Controls:MetroWindow.TitleTemplate>
+        <DataTemplate>
+            <TextBlock x:Name="TitleText"
+                       Text="Necrobot 2 - PokeDex"
+                       TextTrimming="CharacterEllipsis"
+                       VerticalAlignment="Center"
+                       Margin="7, 0, 0, 0"
+                       FontWeight="Normal"
+                       FontFamily="pack://application:,,,/Resources/#Lato-light"/>
+        </DataTemplate>
+    </Controls:MetroWindow.TitleTemplate>
+    
     <Window.Resources>
         <c:PokemonImageConverter x:Key="PokemonImageConverter" />
     </Window.Resources>

--- a/PoGo.Necrobot.Window/SettingsWindow.xaml
+++ b/PoGo.Necrobot.Window/SettingsWindow.xaml
@@ -1,6 +1,6 @@
 ﻿<Controls:MetroWindow x:Class="PoGo.Necrobot.Window.SettingsWindow"
                       xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
-	                  xmlns:Behaviours="clr-namespace:MahApps.Metro.Behaviours;assembly=MahApps.Metro"
+	              xmlns:Behaviours="clr-namespace:MahApps.Metro.Behaviours;assembly=MahApps.Metro"
                       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                       xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
@@ -12,8 +12,18 @@
                       ResizeMode="CanResizeWithGrip"
                       MinWidth="800"
                       WindowTransitionsEnabled="False"
-                      WindowStartupLocation="CenterScreen" Closed="MetroWindow_Closed"
-                      >
+                      WindowStartupLocation="CenterScreen" Closed="MetroWindow_Closed" >
+    <Controls:MetroWindow.TitleTemplate>
+        <DataTemplate>
+            <TextBlock x:Name="TitleText"
+                       Text="Necrobot 2 - Configuration"
+                       TextTrimming="CharacterEllipsis"
+                       VerticalAlignment="Center"
+                       Margin="7, 0, 0, 0"
+                       FontWeight="Normal"
+                       FontFamily="pack://application:,,,/Resources/#Lato-light"/>
+        </DataTemplate>
+    </Controls:MetroWindow.TitleTemplate>
     <Controls:MetroWindow.RightWindowCommands>
         <Controls:WindowCommands>
             

--- a/PoGo.Necrobot.Window/SplashScreen.xaml
+++ b/PoGo.Necrobot.Window/SplashScreen.xaml
@@ -1,6 +1,6 @@
 ﻿<Controls:MetroWindow x:Class="PoGo.Necrobot.Window.SplashScreen"
-          xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
-                  xmlns:Behaviours="clr-namespace:MahApps.Metro.Behaviours;assembly=MahApps.Metro"
+                      xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+                      xmlns:Behaviours="clr-namespace:MahApps.Metro.Behaviours;assembly=MahApps.Metro"
                       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                       xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
@@ -10,15 +10,24 @@
                       BorderThickness="0" 
                       GlowBrush="Black"
                       ResizeMode="CanResizeWithGrip"
-
                       WindowTransitionsEnabled="False"
-                      WindowStartupLocation="CenterScreen">
+                      WindowStartupLocation="CenterScreen" >
+    <Controls:MetroWindow.TitleTemplate>
+        <DataTemplate>
+            <TextBlock x:Name="TitleText"
+                       Text="Necrobot 2 - Window GUI"
+                       TextTrimming="CharacterEllipsis"
+                       VerticalAlignment="Center"
+                       Margin="7, 0, 0, 0"
+                       FontWeight="Normal"
+                       FontFamily="pack://application:,,,/Resources/#Lato-light"/>
+        </DataTemplate>
+    </Controls:MetroWindow.TitleTemplate>
     <Grid>
 
         <Button x:Name="btnNew" Content="Start New" HorizontalAlignment="Left" Margin="90,70,0,0" VerticalAlignment="Top" Width="165" Height="85"/>
         <Button x:Name="btnOpen" Content="Open Exists" HorizontalAlignment="Left" Margin="345,70,0,0" VerticalAlignment="Top" Width="175" Height="85" Click="btnOpen_Click"/>
-
-        
+ 
     </Grid>
     
 </Controls:MetroWindow>


### PR DESCRIPTION
Description:
This PR Fixes Titles so that they Match the Bot's Font as well as are not caps anymore, LIKE THIS.
It also adds a few fixes to the Code to better organize it

Files Edited:
* PokedexWindow.xaml
* SplashScreen.xaml
* SettingsWindow.xaml
* FilterSetting.xaml
* MainWindow.xaml

Happy Botting, 
CDA 👍 