### PR TITLE
Big clean up of multi bot functionality. Multibot is now always enabled.

### DIFF
--- a/PoGo.NecroBot.CLI/Forms/StarterConfigForm.cs
+++ b/PoGo.NecroBot.CLI/Forms/StarterConfigForm.cs
@@ -51,9 +51,9 @@ namespace PoGo.NecroBot.CLI.Forms
 
         private void wizardPage2_Commit(object sender, WizardPageConfirmEventArgs e)
         {
-            this.settings.Auth.AuthConfig.AuthType = comboBox1.Text == "ptc" ? AuthType.Ptc : AuthType.Google;
-            this.settings.Auth.AuthConfig.Username = txtUsername.Text;
-            this.settings.Auth.AuthConfig.Password = txtPassword.Text;
+            this.settings.Auth.CurrentAuthConfig.AuthType = comboBox1.Text == "ptc" ? AuthType.Ptc : AuthType.Google;
+            this.settings.Auth.CurrentAuthConfig.Username = txtUsername.Text;
+            this.settings.Auth.CurrentAuthConfig.Password = txtPassword.Text;
         }
 
         private void SelectLanguagePage_Commit(object sender, WizardPageConfirmEventArgs e)

--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -452,8 +452,6 @@ namespace PoGo.NecroBot.CLI
                 _session.EventDispatcher.EventReceived += evt => websocket.Listen(evt, _session);
             }
             
-            var mainAccount = accountManager.Add(settings.Auth.AuthConfig);
-
             var bot = accountManager.GetStartUpAccount();
 
             _session.ReInitSessionWithNextBot(bot);

--- a/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Interfaces/Configuration/ILogicSettings.cs
@@ -222,7 +222,6 @@ namespace PoGo.NecroBot.Logic.Interfaces.Configuration
         DataSharingConfig DataSharingConfig { get; }
         MultipleBotConfig MultipleBotConfig { get; }
         List<AuthConfig> Bots { get; }
-        bool AllowMultipleBot { get; }
         CaptchaConfig CaptchaConfig { get; }
         int BulkTransferStogareBuffer { get; }
         int BulkTransferSize { get; }

--- a/PoGo.NecroBot.Logic/Model/Settings/ClientSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/ClientSettings.cs
@@ -67,23 +67,23 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         
         AuthType ISettings.AuthType
         {
-            get { return _settings.Auth.AuthConfig.AuthType; }
+            get { return _settings.Auth.CurrentAuthConfig.AuthType; }
 
-            set { _settings.Auth.AuthConfig.AuthType = value; }
+            set { _settings.Auth.CurrentAuthConfig.AuthType = value; }
         }
 
         string ISettings.Username
         {
-            get { return _settings.Auth.AuthConfig.Username; }
+            get { return _settings.Auth.CurrentAuthConfig.Username; }
 
-            set { _settings.Auth.AuthConfig.Username = value; }
+            set { _settings.Auth.CurrentAuthConfig.Username = value; }
         }
 
         string ISettings.Password
         {
-            get { return _settings.Auth.AuthConfig.Password; }
+            get { return _settings.Auth.CurrentAuthConfig.Password; }
 
-            set { _settings.Auth.AuthConfig.Password = value; }
+            set { _settings.Auth.CurrentAuthConfig.Password = value; }
         }
         
         #endregion Auth Config Values

--- a/PoGo.NecroBot.Logic/Model/Settings/GlobalSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/GlobalSettings.cs
@@ -162,13 +162,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
                 });
             }
 
-            if(allAcc.Count>0)
-            {
-                this.Auth.AuthConfig = allAcc.First();
-            }
-            this.Auth.Bots = allAcc.Skip(1).ToList();
-            if (this.Auth.Bots.Count > 0) this.Auth.AllowMultipleBot = true;
-
+            this.Auth.Bots = allAcc.ToList();
             string json = JsonConvert.SerializeObject(this.Auth, Formatting.Indented,new StringEnumConverter() { CamelCaseText = true });
 
             File.WriteAllText("config\\auth.json", json);
@@ -904,10 +898,10 @@ namespace PoGo.NecroBot.Logic.Model.Settings
             switch (accountType)
             {
                 case "google":
-                    settings.Auth.AuthConfig.AuthType = AuthType.Google;
+                    settings.Auth.CurrentAuthConfig.AuthType = AuthType.Google;
                     break;
                 case "ptc":
-                    settings.Auth.AuthConfig.AuthType = AuthType.Ptc;
+                    settings.Auth.CurrentAuthConfig.AuthType = AuthType.Ptc;
                     break;
             }
 
@@ -925,7 +919,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
                 translator.GetTranslation(TranslationString.FirstStartSetupUsernamePrompt)
             );
 
-            settings.Auth.AuthConfig.Username = strInput;
+            settings.Auth.CurrentAuthConfig.Username = strInput;
             Logger.Write(translator.GetTranslation(TranslationString.FirstStartSetupUsernameConfirm, strInput));
 
             Logger.Write("", LogLevel.Info);
@@ -934,7 +928,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
                 translator.GetTranslation(TranslationString.FirstStartSetupPasswordPrompt)
             );
 
-            settings.Auth.AuthConfig.Password = strInput;
+            settings.Auth.CurrentAuthConfig.Password = strInput;
             Logger.Write(translator.GetTranslation(TranslationString.FirstStartSetupPasswordConfirm, strInput));
 
             Logger.Write(translator.GetTranslation(TranslationString.FirstStartAccountCompleted), LogLevel.Info);

--- a/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/LogicSettings.cs
@@ -271,7 +271,6 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public bool UseTransferFilterToCatch => _settings.CustomCatchConfig.UseTransferFilterToCatch;
         public MultipleBotConfig MultipleBotConfig => _settings.MultipleBotConfig;
         public List<AuthConfig> Bots => _settings.Auth.Bots;
-        public bool AllowMultipleBot => _settings.Auth.AllowMultipleBot;
         public int MinIVForAutoSnipe => _settings.SnipeConfig.MinIVForAutoSnipe;
         public bool AutosnipeVerifiedOnly => _settings.SnipeConfig.AutosnipeVerifiedOnly;
         public int DefaultAutoSnipeCandy => _settings.SnipeConfig.DefaultAutoSnipeCandy;

--- a/PoGo.NecroBot.Logic/Model/Settings/MultipleBotConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/MultipleBotConfig.cs
@@ -198,7 +198,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
 
         public static bool IsMultiBotActive(ILogicSettings logicSettings)
         {
-            return logicSettings.AllowMultipleBot && logicSettings.Bots != null && logicSettings.Bots.Count >= 1;
+            return logicSettings.Bots != null && logicSettings.Bots.Count >= 1;
         }
     }
 }

--- a/PoGo.NecroBot.Logic/Model/Settings/UpdateConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/UpdateConfig.cs
@@ -10,7 +10,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         {
         }
 
-        public const int CURRENT_SCHEMA_VERSION = 20;
+        public const int CURRENT_SCHEMA_VERSION = 21;
 
         [DefaultValue(CURRENT_SCHEMA_VERSION)]
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 1)]

--- a/PoGo.NecroBot.Logic/MultiAccountManager.cs
+++ b/PoGo.NecroBot.Logic/MultiAccountManager.cs
@@ -84,7 +84,7 @@ namespace PoGo.NecroBot.Logic
         {
             MigrateDatabase();
             LoadDataFromDB();
-            SyncDatabase(accounts, true /* remove missing accounts */);
+            SyncDatabase(accounts);
         }
 
         public BotAccount GetCurrentAccount()
@@ -190,7 +190,7 @@ namespace PoGo.NecroBot.Logic
             }
         }
 
-        private void SyncDatabase(List<AuthConfig> accounts, bool removeMissingAccounts)
+        private void SyncDatabase(List<AuthConfig> accounts)
         {
             if (accounts.Count() == 0)
                 return;
@@ -226,24 +226,21 @@ namespace PoGo.NecroBot.Logic
                     }
                 }
 
-                if (removeMissingAccounts)
+                // Remove accounts that are not in the auth.json but in the database.
+                List<BotAccount> accountsToRemove = new List<BotAccount>();
+                foreach (var item in this.Accounts)
                 {
-                    // Remove accounts that are not in the auth.json but in the database.
-                    List<BotAccount> accountsToRemove = new List<BotAccount>();
-                    foreach (var item in this.Accounts)
+                    var existing = accounts.FirstOrDefault(x => x.Username == item.Username && x.AuthType == item.AuthType);
+                    if (existing == null)
                     {
-                        var existing = accounts.FirstOrDefault(x => x.Username == item.Username && x.AuthType == item.AuthType);
-                        if (existing == null)
-                        {
-                            accountsToRemove.Add(item);
-                        }
+                        accountsToRemove.Add(item);
                     }
+                }
 
-                    foreach (var item in accountsToRemove)
-                    {
-                        this.Accounts.Remove(item);
-                        accountdb.Delete(item.Id);
-                    }
+                foreach (var item in accountsToRemove)
+                {
+                    this.Accounts.Remove(item);
+                    accountdb.Delete(item.Id);
                 }
             }
         }
@@ -253,28 +250,13 @@ namespace PoGo.NecroBot.Logic
             return this.Accounts.OrderBy(x => x.RuntimeTotal).Where(x => !ignoreBlockCheck || x.ReleaseBlockTime < DateTime.Now).FirstOrDefault();
         }
 
-        public BotAccount Add(AuthConfig authConfig)
-        {
-            SyncDatabase(new List<AuthConfig>() { authConfig }, false /* don't remove missing accounts */);
-
-            return this.Accounts.Last();
-        }
-
         public BotAccount GetStartUpAccount()
         {
             ISession session = TinyIoC.TinyIoCContainer.Current.Resolve<ISession>();
 
-            if (!session.LogicSettings.AllowMultipleBot)
-            {
-                runningAccount = Accounts.Last();
-            }
-            else
-            {
-                runningAccount = GetMinRuntime(true);
-            }
-
-            if (session.LogicSettings.AllowMultipleBot
-              && session.LogicSettings.MultipleBotConfig.SelectAccountOnStartUp)
+            runningAccount = GetMinRuntime(true);
+            
+            if (session.LogicSettings.MultipleBotConfig.SelectAccountOnStartUp)
             {
                 SelectAccountForm f = new SelectAccountForm();
                 f.ShowDialog();

--- a/PoGo.NecroBot.Logic/Service/TelegramCommand/AccountsCommand.cs
+++ b/PoGo.NecroBot.Logic/Service/TelegramCommand/AccountsCommand.cs
@@ -30,20 +30,14 @@ namespace PoGo.NecroBot.Logic.Service.TelegramCommand
                 return false;
             }
 
-            if (session.LogicSettings.AllowMultipleBot)
-            {
-                var manager = TinyIoCContainer.Current.Resolve<MultiAccountManager>();
+            var manager = TinyIoCContainer.Current.Resolve<MultiAccountManager>();
 
-                foreach (var item in manager.Accounts)
-                {
-                    message = message +
-                              $"{item.Username}({item.AuthType})     {item.Level}     {item.GetRuntime()}\r\n";
-                }
-            }
-            else
+            foreach (var item in manager.Accounts)
             {
-                message = message + "Multiple bot is disabled. please use /profile for current account details";
+                message = message +
+                            $"{item.Username}({item.AuthType})     {item.Level}     {item.GetRuntime()}\r\n";
             }
+            
             callback(message);
             return true;
         }

--- a/PoGo.NecroBot.Logic/State/Session.cs
+++ b/PoGo.NecroBot.Logic/State/Session.cs
@@ -199,9 +199,8 @@ namespace PoGo.NecroBot.Logic.State
 
             var nextBot = manager.GetSwitchableAccount(bot);
 
-            this.Settings.AuthType = nextBot.AuthType;
-            this.Settings.Password = nextBot.Password;
-            this.Settings.Username = nextBot.Username;
+            this.GlobalSettings.Auth.CurrentAuthConfig = nextBot;
+            
             this.Settings.DefaultAltitude = att == 0 ? this.Client.CurrentAltitude : att;
             this.Settings.DefaultLatitude = lat == 0 ? this.Client.CurrentLatitude : lat;
             this.Settings.DefaultLongitude = lng == 0 ? this.Client.CurrentLongitude : lng;

--- a/PoGo.NecroBot.Logic/Tasks/CatchNearbyPokemonsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchNearbyPokemonsTask.cs
@@ -44,8 +44,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             if (session.Stats.CatchThresholdExceeds(session))
             {
-                if (session.LogicSettings.AllowMultipleBot &&
-                    session.LogicSettings.MultipleBotConfig.SwitchOnCatchLimit &&
+                if (session.LogicSettings.MultipleBotConfig.SwitchOnCatchLimit &&
                     TinyIoCContainer.Current.Resolve<MultiAccountManager>().AllowSwitch()
                     )
                 {

--- a/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
@@ -85,8 +85,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             // Exit if user defined max limits reached
             if (session.Stats.CatchThresholdExceeds(session))
             {
-                if (session.LogicSettings.AllowMultipleBot &&
-                    session.LogicSettings.MultipleBotConfig.SwitchOnCatchLimit &&
+                if (session.LogicSettings.MultipleBotConfig.SwitchOnCatchLimit &&
                         TinyIoCContainer.Current.Resolve<MultiAccountManager>().AllowSwitch())
                 {
                     throw new ActiveSwitchByRuleException()
@@ -534,7 +533,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                         Logger.Write("Seem that bot has ben catch flee softban, Bot will start save 100 balls to by pass it.");
                         
                     }
-                    if (session.LogicSettings.AllowMultipleBot && !session.LogicSettings.ByPassCatchFlee)
+                    if (!session.LogicSettings.ByPassCatchFlee)
                     {
                         if (CatchFleeContinuouslyCount > session.LogicSettings.MultipleBotConfig.CatchFleeCount &&
                             TinyIoCContainer.Current.Resolve<MultiAccountManager>().AllowSwitch())
@@ -609,8 +608,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                 if (session.LogicSettings.PokemonSnipeFilters.ContainsKey(encounterEV.PokemonId))
                 {
                     var filter = session.LogicSettings.PokemonSnipeFilters[encounterEV.PokemonId];
-                    if (session.LogicSettings.AllowMultipleBot &&
-                        filter.AllowMultiAccountSnipe &&
+                    if (filter.AllowMultiAccountSnipe &&
                         filter.IsMatch(encounterEV.IV,
                         (PokemonMove)Enum.Parse(typeof(PokemonMove), encounterEV.Move1),
                         (PokemonMove)Enum.Parse(typeof(PokemonMove), encounterEV.Move2),


### PR DESCRIPTION
## Short Description:
Big clean up of multibot functionality:

1) Clean up auth.json.  There is now only one `Bots` section which contains all authentication info. The old `AuthConfig` in auth.json is now removed.
2) Multibot is always enabled now. So there is no need for `AllowMultipleBot` in auth.json.

## Fixes (provide links to github issues if you can):
Fixes #1161