### PR TITLE
Update sprites

### DIFF
--- a/PoGo.Necrobot.Window/Converters/PokemonIdToImageConverter.cs
+++ b/PoGo.Necrobot.Window/Converters/PokemonIdToImageConverter.cs
@@ -16,13 +16,8 @@ namespace PoGo.Necrobot.Window.Converters
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var pokemonId = (PokemonId)value;
-            if ((int)pokemonId > 151)
-            {
-                //http://www.serebii.net/pokemongo/pokemon/145.png maybe better
-                return $"https://rankedboost.com/wp-content/plugins/ice/riot/poksimages/pokemons2/{(int)pokemonId:000}.png";
-            }
 
-            return $"https://rankedboost.com/wp-content/plugins/ice/riot/poksimages/pokemons/{(int)pokemonId:000}.png";
+            return $"http://www.serebii.net/pokemongo/pokemon/{(int)pokemonId:000}.png";
 
         }
 

--- a/PoGo.Necrobot.Window/Converters/PokemonImageConverter.cs
+++ b/PoGo.Necrobot.Window/Converters/PokemonImageConverter.cs
@@ -14,14 +14,7 @@ namespace PoGo.Necrobot.Window.Converters
         {
             var id = (int)value;
 
-            if (id > 151)
-            {
-
-                return $"https://rankedboost.com/wp-content/plugins/ice/riot/poksimages/pokemons2/{id:000}.png";
-
-            }
-
-            return $"https://rankedboost.com/wp-content/plugins/ice/riot/poksimages/pokemons/{id:000}.png";
+            return $"http://www.serebii.net/pokemongo/pokemon/{id:000}.png";
 
         }
 


### PR DESCRIPTION
## Short Desc
Updates Sprites

## Reason
* Well Sprites in serebii has more Gen2 Themed sprites than rankedboost ripped from Pokemon GO they have them for the most mons and the sprites which are still not available they use the ripped of sprites from Pokemon XY/ORAS also they regularly update their site and add newer sprites.

* serebii has all the sprites together in one directory so it also shortens the code by a bit