### PR TITLE
Fix auto updater to download versioned zip from BinTray.

### DIFF
--- a/PoGo.NecroBot.Logic/State/VersionCheckState.cs
+++ b/PoGo.NecroBot.Logic/State/VersionCheckState.cs
@@ -32,6 +32,9 @@ namespace PoGo.NecroBot.Logic.State
         public const string LatestReleaseApi =
             "https://api.github.com/repos/Necrobot-Private/NecroBot/releases/latest";
 
+        public const string RemoteReleaseUrl =
+            "https://dl.bintray.com/necrobot-private/NecroBot2/:"; // Note that this url ends with a colon on purpose.
+
         public static Version RemoteVersion;
 
         public async Task<IState> Execute(ISession session, CancellationToken cancellationToken)
@@ -64,15 +67,13 @@ namespace PoGo.NecroBot.Logic.State
             }
 
             SystemSounds.Asterisk.Play();
-
-            var remoteReleaseUrl =
-                $"https://github.com/Necrobot-Private/NecroBot/releases/download/v{RemoteVersion}/";
-            string zipName = "NecroBot2.Console.zip";
+            
+            string zipName = $"NecroBot2.Console.{RemoteVersion.ToString()}.zip";
             if (Assembly.GetEntryAssembly().FullName.ToLower().Contains("necrobot2.win"))
             {
-                zipName = "NecroBot2.Win.zip";
+                zipName = $"NecroBot2.WIN.{RemoteVersion.ToString()}.zip";
             }
-            var downloadLink = remoteReleaseUrl + zipName;
+            var downloadLink = RemoteReleaseUrl + zipName;
 
             var baseDir = Directory.GetCurrentDirectory();
             var downloadFilePath = Path.Combine(baseDir, zipName);


### PR DESCRIPTION
## Short Description:
Fixing auto updater for bintray:
1) We now need to use versioned zip files (instead of NecroBot.Console.zip it is now NecroBot.Console.1.0.0.141.zip).
2) Downloads should come from BinTray and not Github.
