### PR TITLE
Minor Text Fixes + Edits to PostBuild Command

### DIFF
--- a/PoGo.NecroBot.CLI/Properties/AssemblyInfo.cs
+++ b/PoGo.NecroBot.CLI/Properties/AssemblyInfo.cs
@@ -40,7 +40,7 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion1("1.0.0.134")]
 
 
-[assembly: AssemblyVersion("1.0.0.147")]
+[assembly: AssemblyVersion("1.0.0.148")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("v1.0.0.147")]
+[assembly: AssemblyInformationalVersion("v1.0.0.148")]
 

--- a/PoGo.NecroBot.Logic/Properties/AssemblyInfo.cs
+++ b/PoGo.NecroBot.Logic/Properties/AssemblyInfo.cs
@@ -40,6 +40,6 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion1("1.0.0.134")]
 
 
-[assembly: AssemblyVersion("1.0.0.147")]
+[assembly: AssemblyVersion("1.0.0.148")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("v1.0.0.147")]
+[assembly: AssemblyInformationalVersion("v1.0.0.148")]

--- a/PoGo.Necrobot.Window/PoGo.Necrobot.Window.csproj
+++ b/PoGo.Necrobot.Window/PoGo.Necrobot.Window.csproj
@@ -630,7 +630,7 @@ foreach (var item in filesToCleanup)
   <PropertyGroup>
     <PostBuildEvent>cd "$(TargetDir)"
 del *.config
-xcopy /y /f /e "$(SolutionDir)\PoGo.NecroBot.GUI.Electron\PokeEase-Necrobot-Private" "$(TargetDir)\PokeEase\"</PostBuildEvent>
+xcopy /y /f /e "$(SolutionDir)\PokeEase\Public" "$(TargetDir)\PokeEase\"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
This PR fixes a few typos as well as changing the PostBuild command to copy From the actual PokeEase Submodule rather than the electron gui version, resulting in a more updated pokeease