### PR TITLE
Update translation.zh-TW.json

### DIFF
--- a/PoGo.NecroBot.CLI/Config/Translations/translation.zh-TW.json
+++ b/PoGo.NecroBot.CLI/Config/Translations/translation.zh-TW.json
@@ -86,11 +86,11 @@
     },
     {
       "Key": "gym",
-      "Value": "Gym"
+      "Value": "道場"
     },
     {
       "Key": "pokestop",
-      "Value": "Pokestop"
+      "Value": "補給站"
     },
     {
       "Key": "eventFortTargeted",
@@ -1894,7 +1894,7 @@
     },
     {
       "Key": "absorb",
-      "Value": "Absorb"
+      "Value": "吸取"
     },
     {
       "Key": "gigaDrain",
@@ -2155,6 +2155,10 @@
     {
       "Key": "fireFangFast",
       "Value": "炎牙"
+    },
+    {
+      "Key": "CloseCombat",
+      "Value": "肉搏戰"
     },
     {
       "Key": "rockSmashFast",


### PR DESCRIPTION
## Short Description:
I observed there's some translation missed in Tradition Chinese.  
So I request to add some translation as below,  

## Fixes (provide links to github issues if you can):
1. Gym = 道場
2. pokestop = 補給站
3. Absorb = 吸取  
Added lost key "CloseCombat" and added it's value "肉搏戰"歐.  