### PR TITLE
Fixes #1442 - Upgrade all LiteDB 3.0 databases.

### DIFF
--- a/PoGo.NecroBot.Logic/Model/ElevationLocation.cs
+++ b/PoGo.NecroBot.Logic/Model/ElevationLocation.cs
@@ -70,7 +70,8 @@ namespace PoGo.NecroBot.Logic.Model
                 {
                     Directory.CreateDirectory(CACHE_DIR);
                 }
-
+                
+                LiteEngine.Upgrade(DB_NAME, null, true);
                 using (var db = new LiteDatabase(DB_NAME))
                 {
                     db.GetCollection<ElevationLocation>("locations").EnsureIndex(s => s.Id);

--- a/PoGo.NecroBot.Logic/Model/GeoLocation.cs
+++ b/PoGo.NecroBot.Logic/Model/GeoLocation.cs
@@ -97,6 +97,7 @@ namespace PoGo.NecroBot.Logic.Model
                     Directory.CreateDirectory(CACHE_DIR);
                 }
 
+                LiteEngine.Upgrade(DB_NAME, null, true);
                 using (var db = new LiteDatabase(DB_NAME))
                 {
                     db.GetCollection<GeoLocation>("locations").EnsureIndex(s => s.Id);

--- a/PoGo.NecroBot.Logic/MultiAccountManager.cs
+++ b/PoGo.NecroBot.Logic/MultiAccountManager.cs
@@ -107,6 +107,7 @@ namespace PoGo.NecroBot.Logic
 
         private void LoadDataFromDB()
         {
+            LiteEngine.Upgrade(ACCOUNT_DB_NAME, null, true);
             using (var db = new LiteDatabase(ACCOUNT_DB_NAME))
             {
                 var accountdb = db.GetCollection<BotAccount>("accounts");

--- a/PoGo.NecroBot.Logic/State/SessionStats.cs
+++ b/PoGo.NecroBot.Logic/State/SessionStats.cs
@@ -141,7 +141,9 @@ namespace PoGo.NecroBot.Logic.State
                 return;
             }
 
-            using (var db = new LiteDatabase(GetDBPath(username)))
+            var dbPath = GetDBPath(username);
+            LiteEngine.Upgrade(dbPath, null, true);
+            using (var db = new LiteDatabase(dbPath))
             {
                 db.GetCollection<PokeStopTimestamp>(POKESTOP_STATS_COLLECTION).EnsureIndex(s => s.Timestamp);
                 db.GetCollection<PokemonTimestamp>(POKEMON_STATS_COLLECTION).EnsureIndex(s => s.Timestamp);


### PR DESCRIPTION
## Short Description:
v152 introduced a bug in loading the 4 litedb databases that we use for storing data. We need to migrate the databases in order to be able to load them again.

## Fixes (provide links to github issues if you can):
Fixes #1442