### PR TITLE
Fix runtime totals when multibotting

### DIFF
--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -356,7 +356,7 @@ namespace PoGo.NecroBot.CLI
 
             Logger.SetLoggerContext(_session);
 
-            MultiAccountManager accountManager = new MultiAccountManager(logicSettings.Bots);
+            MultiAccountManager accountManager = new MultiAccountManager(settings, logicSettings.Bots);
             ioc.Register(accountManager);
 
             if (boolNeedsSetup)

--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -69,14 +69,10 @@ namespace PoGo.NecroBot.Logic
             _client = client;
             _logicSettings = logicSettings;
             // Inventory update will be called everytime GetMapObject is called.
-            client.Inventory.OnInventoryUpdated += async () =>
+            client.Inventory.OnInventoryUpdated += () =>
             {
                 if (onUpdated != null && _player != null)
                 {
-                    var accManager = TinyIoCContainer.Current.Resolve<MultiAccountManager>();
-                    if (accManager != null)
-                        await accManager.UpdateCurrentAccountLevel().ConfigureAwait(false);
-
                     onUpdated();
                 }
             };

--- a/PoGo.NecroBot.Logic/Model/Settings/AuthConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/AuthConfig.cs
@@ -29,35 +29,6 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         [JsonProperty(Required = Required.Default, DefaultValueHandling = DefaultValueHandling.Populate, Order = 3)]
         public string Password { get; set; }
         
-        // Deprecated - Will be removed next release, but left here so that we can do migration.
-        [DefaultValue(null)]
-        [RegularExpression(@"[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?")] // Valid email
-        [MinLength(0)]
-        [MaxLength(64)]
-        [JsonProperty(Required = Required.Default, DefaultValueHandling = DefaultValueHandling.Ignore, Order = 4)]
-        public string GoogleUsername { get; set; }
-
-        // Deprecated - Will be removed next release, but left here so that we can do migration.
-        [DefaultValue(null)]
-        [MinLength(0)]
-        [MaxLength(50)]
-        [JsonProperty(Required = Required.Default, DefaultValueHandling = DefaultValueHandling.Ignore, Order = 5)]
-        public string GooglePassword { get; set; }
-
-        // Deprecated - Will be removed next release, but left here so that we can do migration.
-        [DefaultValue(null)]
-        [MinLength(0)]
-        [MaxLength(32)]
-        [JsonProperty(Required = Required.Default, DefaultValueHandling = DefaultValueHandling.Ignore, Order = 6)]
-        public string PtcUsername { get; set; }
-
-        // Deprecated - Will be removed next release, but left here so that we can do migration.
-        [DefaultValue(null)]
-        [MinLength(0)]
-        [MaxLength(32)]
-        [JsonProperty(Required = Required.Default, DefaultValueHandling = DefaultValueHandling.Ignore, Order = 7)]
-        public string PtcPassword { get; set; }
-
         // Total runtime since client started
         [JsonIgnore]
         public double RuntimeTotal { get; set; }

--- a/PoGo.NecroBot.Logic/Model/Settings/AuthConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/AuthConfig.cs
@@ -58,8 +58,12 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         [JsonProperty(Required = Required.Default, DefaultValueHandling = DefaultValueHandling.Ignore, Order = 7)]
         public string PtcPassword { get; set; }
 
+        // Total runtime since client started
         [JsonIgnore]
         public double RuntimeTotal { get; set; }
+        
+        [JsonIgnore]
+        public DateTime LastRuntimeUpdatedAt { get; set; }
 
         [JsonIgnore]
         public DateTime ReleaseBlockTime { get; set; }

--- a/PoGo.NecroBot.Logic/Model/Settings/AuthSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/AuthSettings.cs
@@ -35,10 +35,6 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         [JsonIgnore]
         private string _filePath;
 
-        // Deprecated and will be removed in future release.
-        [JsonProperty(Required = Required.Default, DefaultValueHandling = DefaultValueHandling.Ignore, Order = 1)]
-        public AuthConfig AuthConfig = null;
-
         [JsonProperty(Required = Required.Default, DefaultValueHandling = DefaultValueHandling.Ignore, Order = 1)]
         public List<AuthConfig> Bots = new List<AuthConfig>();
 

--- a/PoGo.NecroBot.Logic/Model/Settings/GlobalSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/GlobalSettings.cs
@@ -155,10 +155,8 @@ namespace PoGo.NecroBot.Logic.Model.Settings
                 allAcc.Add(new AuthConfig()
                 {
                     AuthType = isGoogle ? AuthType.Google : AuthType.Ptc,
-                    GoogleUsername = isGoogle ? string.Format(template, i) : null,
-                    GooglePassword = isGoogle ? password : null,
-                    PtcUsername = !isGoogle ? string.Format(template, i) : null,
-                    PtcPassword = !isGoogle ? password : null,
+                    Username = string.Format(template, i),
+                    Password = password
                 });
             }
 

--- a/PoGo.NecroBot.Logic/State/LoginState.cs
+++ b/PoGo.NecroBot.Logic/State/LoginState.cs
@@ -348,7 +348,9 @@ namespace PoGo.NecroBot.Logic.State
                 session.Profile = await session.Inventory.GetPlayerData().ConfigureAwait(false);
                 var stats = await session.Inventory.GetPlayerStats().ConfigureAwait(false);
 
-                TinyIoCContainer.Current.Resolve<MultiAccountManager>().Logged(session.Profile, stats);
+                // TODO Remove
+                //TinyIoCContainer.Current.Resolve<MultiAccountManager>().Logged(session.Profile, stats);
+
                 session.EventDispatcher.Send(new ProfileEvent {Profile = session.Profile, Stats = stats});
             }
             catch (UriFormatException e)

--- a/PoGo.NecroBot.Logic/State/Session.cs
+++ b/PoGo.NecroBot.Logic/State/Session.cs
@@ -196,8 +196,8 @@ namespace PoGo.NecroBot.Logic.State
             var manager = TinyIoCContainer.Current.Resolve<MultiAccountManager>();
 
             var nextBot = manager.GetSwitchableAccount(bot);
-
-            GlobalSettings.Auth.CurrentAuthConfig = nextBot;
+            if (nextBot != null)
+                manager.SwitchAccounts(nextBot);
 
             Settings.DefaultAltitude = att == 0 ? Client.CurrentAltitude : att;
             Settings.DefaultLatitude = lat == 0 ? Client.CurrentLatitude : lat;

--- a/PoGo.Necrobot.Window/Converters/DurationTextConverter.cs
+++ b/PoGo.Necrobot.Window/Converters/DurationTextConverter.cs
@@ -6,16 +6,15 @@ namespace PoGo.Necrobot.Window.Converters
 {
     public class DurationTextConverter : IValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public object Convert(object minutes, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value == null)
+            if (minutes == null)
                 return null;
 
-            var duration = (double)value;
-            int day = (int)duration / 1440;
-            int hour = (int)(duration - (day * 1400)) / 60;
-            int min = (int)(duration - (day * 1400) - hour * 60);
-            return $"{day:00}:{hour:00}:{min:00}:00";
+            var seconds = (int)((double)minutes * 60);
+            var duration = new TimeSpan(0, 0, seconds);
+
+            return duration.ToString(@"dd\:hh\:mm\:ss");
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)


### PR DESCRIPTION
## Short Description:
Fixes the runtime total for the bot to be accurate now.  There is a change in the behavior of this now in that we now reset the runtime totals when the bot is started..  Since this runtime total was previously never reset, nor was there a way to manually reset the value (except deleting the database file), the best compromise was to just reset it when the bot starts up.

## Fixes (provide links to github issues if you can):
Fixes #1392 
Fixes #1451