### PR TITLE
Fix ordering of bot runtime when runtime total is equal.

### DIFF
--- a/PoGo.NecroBot.Logic/MultiAccountManager.cs
+++ b/PoGo.NecroBot.Logic/MultiAccountManager.cs
@@ -314,7 +314,7 @@ namespace PoGo.NecroBot.Logic
             {
                 var accountdb = db.GetCollection<BotAccount>("accounts");
                 
-                var runnableAccount = Accounts.OrderByDescending(p => p.RuntimeTotal).LastOrDefault(p => p != currentAccount && p.ReleaseBlockTime < DateTime.Now);
+                var runnableAccount = Accounts.OrderByDescending(p => p.RuntimeTotal).ThenBy(p => p.Id).LastOrDefault(p => p != currentAccount && p.ReleaseBlockTime < DateTime.Now);
 
                 if (runnableAccount != null)
                     return runnableAccount;


### PR DESCRIPTION
## Short Description:
When runtime is equal (i.e. 0 on first startup), we should sort accounts by their ID.

## Fixes (provide links to github issues if you can):
Fixes #1477