### PR TITLE
Fix Android device variables when generating random iOS device.

### DIFF
--- a/PoGo.NecroBot.Logic/Model/Settings/AuthSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/AuthSettings.cs
@@ -238,7 +238,12 @@ namespace PoGo.NecroBot.Logic.Model.Settings
                     {
                         var randomAppleDeviceInfo = DeviceInfoHelper.GetRandomIosDevice();
                         SetDevInfoByDeviceInfo(randomAppleDeviceInfo);
-
+                        // Clearing Android variables, as they come back "" instead of null
+                        DeviceConfig.AndroidBoardName = null;
+                        DeviceConfig.AndroidBootloader = null;
+                        DeviceConfig.DeviceModelIdentifier = null;
+                        DeviceConfig.FirmwareTags = null;
+                        DeviceConfig.FirmwareFingerprint = null;
                         // After generating iOS settings, automatically set the package name to "custom", so that we don't regenerate settings every time we start.
                         DeviceConfig.DevicePackageName = "custom";
                     }


### PR DESCRIPTION
When setting auth.json DevicePackageName to "random" device is
generated, but sets android-related values to "" instead of null.  Fix
sets the five values to null on random device generation.

Wasn't able to set these in call to generate the device.  Tested, and properly sets Android device information to null instead of "".

Error was during auth.json verification:
[20:28:18] () Validating Auth.json...
[20:28:18] () auth.json [Line: 21, Position: 26]: DeviceConfig.AndroidBoardName String '' does not match regex pattern '[a-zA-Z0-9_\-\.\s]'.
[20:28:18] () auth.json [Line: 22, Position: 27]: DeviceConfig.AndroidBootloader String '' does not match regex pattern '[a-zA-Z0-9_\-\.\s]'.
[20:28:18] () auth.json [Line: 25, Position: 31]: DeviceConfig.DeviceModelIdentifier String '' does not match regex pattern '[a-zA-Z0-9_\-\.\s]'.
[20:28:18] () auth.json [Line: 30, Position: 22]: DeviceConfig.FirmwareTags String '' does not match regex pattern '[a-zA-Z0-9_\-\.\s]'.
[20:28:18] () auth.json [Line: 32, Position: 29]: DeviceConfig.FirmwareFingerprint String '' does not match regex pattern '[[a-zA-Z0-9_\-\/\.\:]'.
[20:28:18] () Fix your auth.json and restart NecroBot or press any key to ignore and continue...