### PR TITLE
Decrease softban limits (500 pokemon, 700 pokestops)

### DIFF
--- a/PoGo.NecroBot.Logic/Model/Settings/GlobalSettings.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/GlobalSettings.cs
@@ -682,7 +682,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
                         break;
 
                     case 22:
-                        if (settings["PokemonsTransferFilter"] != null && settings["PokemonsTransferFilter"] != null)
+                        if (settings["PokemonsTransferFilter"] != null)
                         {
                             foreach (var x in settings["PokemonsTransferFilter"])
                             {
@@ -692,6 +692,19 @@ namespace PoGo.NecroBot.Logic.Model.Settings
                                 if (filter["KeepMaxDuplicatePokemon"] == null)
                                     filter["KeepMaxDuplicatePokemon"] = 1000;
                             }
+                        }
+                        break;
+
+                    case 23:
+                        if (settings["PokeStopConfig"] != null)
+                        {
+                            settings["PokeStopConfig"]["PokeStopLimit"] = 700;
+                            Logger.Write($"PokeStopLimit changed to {settings["PokeStopConfig"]["PokeStopLimit"]}", LogLevel.Info);
+                        }
+                        if (settings["PokemonConfig"] != null)
+                        {
+                            settings["PokemonConfig"]["CatchPokemonLimit"] = 500;
+                            Logger.Write($"CatchPokemonLimit changed to {settings["PokemonConfig"]["CatchPokemonLimit"]}", LogLevel.Info);
                         }
                         break;
                 }

--- a/PoGo.NecroBot.Logic/Model/Settings/PokeStopConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/PokeStopConfig.cs
@@ -17,7 +17,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public bool UsePokeStopLimit { get; set; }
 
         [NecrobotConfig(Description = "Max number of pokestops bot is allowed to farm a day", Position = 2)]
-        [DefaultValue(1500)]
+        [DefaultValue(700)]
         [Range(0, 9999)]
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 2)]
         public int PokeStopLimit {get; set; }

--- a/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/PokemonConfig.cs
@@ -42,7 +42,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         public bool UseCatchLimit { get; set; }
 
         [NecrobotConfig(Description = "Number of pokemon allowed for catch duration", Position = 4)]
-        [DefaultValue(700)]
+        [DefaultValue(500)]
         [Range(0, 9999)]
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 4)]
         public int CatchPokemonLimit { get; set; }

--- a/PoGo.NecroBot.Logic/Model/Settings/UpdateConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/UpdateConfig.cs
@@ -10,7 +10,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         {
         }
 
-        public const int CURRENT_SCHEMA_VERSION = 23;
+        public const int CURRENT_SCHEMA_VERSION = 24;
 
         [DefaultValue(CURRENT_SCHEMA_VERSION)]
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 1)]


### PR DESCRIPTION
## Short Description:
Looks like Niantic has added new limits for number of pokemon caught and pokestops spun. The limits are now dynamically changing according to the data that we have. Based on users in the PogoDev forum, here's how it seems to work:

New accounts have limits of 2100 pokestops and 1500 pokemon before you get softbanned.
If exceed half of the limit (e.g. around 750), then the next day the limits seem to be decreased to 500.
And then if you hit the limit again that day, then the limits are decreased to 200 or 300 the following day.

This pull sets the limits per day to 500 pokemons and 700 pokestops to avoid getting softbanned.

## Fixes (provide links to github issues if you can):
Fixes #1558