### PR TITLE
Add empty checks for username and password when importing auth info.

### DIFF
--- a/PoGo.NecroBot.Logic/MultiAccountManager.cs
+++ b/PoGo.NecroBot.Logic/MultiAccountManager.cs
@@ -192,6 +192,9 @@ namespace PoGo.NecroBot.Logic
                 var liteDbAccounts = liteDb.GetCollection<BotAccount>("accounts");
                 foreach (var liteDbAccount in liteDbAccounts.FindAll())
                 {
+                    if (string.IsNullOrEmpty(liteDbAccount.Username) || string.IsNullOrEmpty(liteDbAccount.Password))
+                        continue;
+
                     Account newAccount = new Account();
                     newAccount.AuthType = liteDbAccount.AuthType;
                     newAccount.Username = liteDbAccount.Username;
@@ -223,6 +226,9 @@ namespace PoGo.NecroBot.Logic
             // Add new accounts and update existing accounts.
             foreach (var authConfig in authConfigs)
             {
+                if (string.IsNullOrEmpty(authConfig.Username) || string.IsNullOrEmpty(authConfig.Password))
+                    continue;
+
                 var existing = _context.Account.FirstOrDefault(x => x.Username == authConfig.Username && x.AuthType == authConfig.AuthType);
 
                 if (existing == null)


### PR DESCRIPTION
## Short Description:
When migrating or loading data from LiteDB to SQLite, we should check for empty username and password to avoid causing error.
