### PR TITLE
Fix gym battle to properly move on if gym is unattackable.

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
@@ -72,9 +72,10 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                 await DoActionAtPokeStop(session, cancellationToken, pokeStop, fortInfo).ConfigureAwait(false);
 
-                await UseGymBattleTask.Execute(session, cancellationToken, pokeStop, fortInfo).ConfigureAwait(false);
+                bool gymAttackSucceeded = await UseGymBattleTask.Execute(session, cancellationToken, pokeStop, fortInfo).ConfigureAwait(false);
 
-                if (fortInfo.Type == FortType.Gym &&
+                if (gymAttackSucceeded &&
+                    fortInfo.Type == FortType.Gym &&
                     (session.GymState.GetGymDetails(session, pokeStop).GymState.FortData.OwnedByTeam == session.Profile.PlayerData.Team || session.GymState.CapturedGymId.Equals(fortInfo.FortId)) &&
                     session.LogicSettings.GymConfig.Enable &&
                     session.LogicSettings.GymConfig.EnableGymTraining)


### PR DESCRIPTION
## Short Description:
We need to fix gym battle logic to move on to the next pokestop/gym when gym is unattackable.

## Fixes (provide links to github issues if you can):
Fixes #1662