### PR TITLE
Updates to PRERELEASE Dependencies - NOT READY TO MERGE

### DIFF
--- a/PoGo.NecroBot.CLI/PoGo.NecroBot.CLI.csproj
+++ b/PoGo.NecroBot.CLI/PoGo.NecroBot.CLI.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -146,9 +146,8 @@
     <Reference Include="AeroWizard, Version=2.1.10.0, Culture=neutral, PublicKeyToken=915e74f5d64b8f37, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\AeroWizard.2.1.10\lib\net452\AeroWizard.dll</HintPath>
     </Reference>
-    <Reference Include="CommandLine, Version=1.9.71.2, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="CommandLine, Version=2.0.275.0, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\CommandLineParser.2.1.1-beta\lib\net45\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="Google.Protobuf, Version=3.3.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Google.Protobuf.3.3.0\lib\net45\Google.Protobuf.dll</HintPath>
@@ -189,8 +188,8 @@
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\Remotion.Linq.2.1.1\lib\net45\Remotion.Linq.dll</HintPath>
+    <Reference Include="Remotion.Linq, Version=2.2.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\Remotion.Linq.2.2.0-alpha-002\lib\net45\Remotion.Linq.dll</HintPath>
     </Reference>
     <Reference Include="SuperSocket.Common, Version=1.6.6.1, Culture=neutral, PublicKeyToken=6c80000676988ebb, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\SuperSocket.1.6.6.1\lib\net45\SuperSocket.Common.dll</HintPath>
@@ -229,8 +228,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Data" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25214-03\lib\net461\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Diagnostics.Tracing, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\System.Diagnostics.Tracing.4.3.0\lib\net462\System.Diagnostics.Tracing.dll</HintPath>
@@ -269,6 +268,9 @@
     <Reference Include="System.Numerics" />
     <Reference Include="System.Reflection, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\System.Reflection.4.3.0\lib\net462\System.Reflection.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reflection.TypeExtensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\System.Reflection.TypeExtensions.4.1.0-rc2-24027\lib\net462\System.Reflection.TypeExtensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>

--- a/PoGo.NecroBot.CLI/PoGo.NecroBot.CLI.csproj
+++ b/PoGo.NecroBot.CLI/PoGo.NecroBot.CLI.csproj
@@ -269,8 +269,8 @@
     <Reference Include="System.Reflection, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\System.Reflection.4.3.0\lib\net462\System.Reflection.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.TypeExtensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\System.Reflection.TypeExtensions.4.1.0-rc2-24027\lib\net462\System.Reflection.TypeExtensions.dll</HintPath>
+    <Reference Include="System.Reflection.TypeExtensions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\System.Reflection.TypeExtensions.4.3.0\lib\net462\System.Reflection.TypeExtensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>

--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -37,20 +37,20 @@ namespace PoGo.NecroBot.CLI
           HelpText = "Init account")]
         public bool Init { get; set; }
 
-        [Option('t', "template", DefaultValue = "", Required = false , HelpText = "Prints all messages to standard output.")]
+        [Option('t', "template", Default = "", Required = false , HelpText = "Prints all messages to standard output.")]
         public string Template { get; set; }
 
-        [Option('p', "password", DefaultValue = "", Required = false, HelpText = "pasword")]
+        [Option('p', "password", Default = "", Required = false, HelpText = "pasword")]
         public string Password { get; set; }
 
-        [Option('g', "google", DefaultValue = false, Required = false,HelpText = "is google account")]
+        [Option('g', "google", Default = false, Required = false, HelpText = "is google account")]
         public bool IsGoogle{ get; set; }
 
-        [Option('s', "start", DefaultValue = 1,HelpText = "Start account", Required = false)]
+        [Option('s', "start", Default = 1,HelpText = "Start account", Required = false)]
         public int Start { get; set; }
 
 
-        [Option('e', "end", DefaultValue = 10, HelpText = "End account",Required = false)]
+        [Option('e', "end", Default = 10, HelpText = "End account", Required = false)]
         public int End { get; set; }
 
         [ParserState]
@@ -216,7 +216,7 @@ namespace PoGo.NecroBot.CLI
             }
 
             var options = new Options();
-            if (CommandLine.Parser.Default.ParseArguments(args, options))
+            if (Parser.Default.ParseArguments(args, options))
             {
                 // Values are available here
                 if (options.Init)

--- a/PoGo.NecroBot.CLI/packages.config
+++ b/PoGo.NecroBot.CLI/packages.config
@@ -53,7 +53,7 @@
   <package id="System.Reflection" version="4.3.0" targetFramework="net462" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net462" />
   <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net462" />
-  <package id="System.Reflection.TypeExtensions" version="4.1.0-rc2-24027" targetFramework="net462" />
+  <package id="System.Reflection.TypeExtensions" version="4.3.0" targetFramework="net462" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net462" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net462" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.3.0" targetFramework="net462" />

--- a/PoGo.NecroBot.CLI/packages.config
+++ b/PoGo.NecroBot.CLI/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AeroWizard" version="2.1.10" targetFramework="net462" />
-  <package id="CommandLineParser" version="1.9.71" targetFramework="net462" />
+  <package id="CommandLineParser" version="2.1.1-beta" targetFramework="net462" />
   <package id="Costura.Fody" version="1.4.1" targetFramework="net462" developmentDependency="true" />
   <package id="Fody" version="2.0.7" targetFramework="net462" developmentDependency="true" />
   <package id="Google.Protobuf" version="3.3.0" targetFramework="net462" />
@@ -19,7 +19,7 @@
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net462" />
-  <package id="Remotion.Linq" version="2.1.1" targetFramework="net462" />
+  <package id="Remotion.Linq" version="2.2.0-alpha-002" targetFramework="net462" />
   <package id="Selenium.Support" version="3.4.0" targetFramework="net462" />
   <package id="Selenium.WebDriver" version="3.4.0" targetFramework="net462" />
   <package id="Selenium.WebDriver.ChromeDriver" version="2.29.0" targetFramework="net462" />
@@ -32,7 +32,7 @@
   <package id="System.ComponentModel" version="4.3.0" targetFramework="net462" />
   <package id="System.Console" version="4.3.0" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net462" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net462" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25214-03" targetFramework="net462" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net462" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net462" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net462" />
@@ -53,6 +53,7 @@
   <package id="System.Reflection" version="4.3.0" targetFramework="net462" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net462" />
   <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net462" />
+  <package id="System.Reflection.TypeExtensions" version="4.1.0-rc2-24027" targetFramework="net462" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net462" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net462" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.3.0" targetFramework="net462" />

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -312,8 +312,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="Telegram.Bot, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\Telegram.Bot.12.0.0-beta-02\lib\netstandard1.1\Telegram.Bot.dll</HintPath>
+    <Reference Include="Telegram.Bot, Version=10.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\Telegram.Bot.10.4.0\lib\net46\Telegram.Bot.dll</HintPath>
     </Reference>
     <Reference Include="WebDriver, Version=3.4.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Selenium.WebDriver.3.4.0\lib\net40\WebDriver.dll</HintPath>

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\packages\SQLite.3.13.0\build\net45\SQLite.props" Condition="Exists('$(SolutionDir)\packages\SQLite.3.13.0\build\net45\SQLite.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -89,13 +89,11 @@
     <Reference Include="BouncyCastle.Crypto, Version=1.8.1.0, Culture=neutral, PublicKeyToken=0e99375e54769942, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Portable.BouncyCastle.1.8.1.2\lib\net4\BouncyCastle.Crypto.dll</HintPath>
     </Reference>
-    <Reference Include="CloudFlareUtilities, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\CloudFlareUtilities.0.2.1-alpha\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\CloudFlareUtilities.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="CloudFlareUtilities, Version=0.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\CloudFlareUtilities.0.4.0-alpha\lib\portable45-net45+win8+wpa81\CloudFlareUtilities.dll</HintPath>
     </Reference>
-    <Reference Include="EngineIoClientDotNet, Version=0.9.22.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\EngineIoClientDotNet.0.9.22\lib\net45\EngineIoClientDotNet.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="EngineIoClientDotNet, Version=0.10.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\EngineIoClientDotNet.0.10.1-beta2\lib\net45\EngineIoClientDotNet.dll</HintPath>
     </Reference>
     <Reference Include="EPPlus, Version=4.1.0.0, Culture=neutral, PublicKeyToken=ea159fdaa78159a1, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\EPPlus.4.1.0\lib\net40\EPPlus.dll</HintPath>
@@ -194,16 +192,18 @@
     <Reference Include="Newtonsoft.Json.Schema, Version=2.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Newtonsoft.Json.Schema.2.0.11\lib\net45\Newtonsoft.Json.Schema.dll</HintPath>
     </Reference>
-    <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\Remotion.Linq.2.1.1\lib\net45\Remotion.Linq.dll</HintPath>
+    <Reference Include="Remotion.Linq, Version=2.2.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\Remotion.Linq.2.2.0-alpha-002\lib\net45\Remotion.Linq.dll</HintPath>
     </Reference>
     <Reference Include="S2Geometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\S2Geometry.1.0.3\lib\portable-net45+wp8+win8\S2Geometry.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SocketIoClientDotNet, Version=0.9.13.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\SocketIoClientDotNet.0.9.13\lib\net45\SocketIoClientDotNet.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SocketIoClientDotNet, Version=0.10.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\SocketIoClientDotNet.0.10.0-beta1\lib\net45\SocketIoClientDotNet.dll</HintPath>
+    </Reference>
+    <Reference Include="SuperSocket.ClientEngine, Version=0.8.0.10, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\SuperSocket.ClientEngine.Core.0.8.0.10\lib\net45\SuperSocket.ClientEngine.dll</HintPath>
     </Reference>
     <Reference Include="SuperSocket.Common, Version=1.6.6.1, Culture=neutral, PublicKeyToken=6c80000676988ebb, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\SuperSocket.1.6.6.1\lib\net45\SuperSocket.Common.dll</HintPath>
@@ -243,8 +243,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Data" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25214-03\lib\net461\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Globalization.Calendars, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -273,6 +273,12 @@
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.NameResolution, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\System.Net.NameResolution.4.3.0\lib\net46\System.Net.NameResolution.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Security, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\System.Net.Security.4.3.0\lib\net46\System.Net.Security.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Sockets, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\System.Net.Sockets.4.3.0\lib\net46\System.Net.Sockets.dll</HintPath>
@@ -306,9 +312,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="Telegram.Bot, Version=10.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\Telegram.Bot.10.4.0\lib\net45\Telegram.Bot.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Telegram.Bot, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\Telegram.Bot.12.0.0-beta-02\lib\netstandard1.1\Telegram.Bot.dll</HintPath>
     </Reference>
     <Reference Include="WebDriver, Version=3.4.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Selenium.WebDriver.3.4.0\lib\net40\WebDriver.dll</HintPath>
@@ -319,9 +324,8 @@
     <Reference Include="websocket-sharp, Version=1.0.2.59611, Culture=neutral, PublicKeyToken=5660b08a1845a91e, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\WebSocketSharp.1.0.3-rc11\lib\websocket-sharp.dll</HintPath>
     </Reference>
-    <Reference Include="WebSocket4Net, Version=0.14.1.0, Culture=neutral, PublicKeyToken=eb4e154b696bf72a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\WebSocket4Net.0.14.1\lib\net45\WebSocket4Net.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="WebSocket4Net, Version=0.15.0.7, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\WebSocket4Net.0.15.0-beta7\lib\net45\WebSocket4Net.dll</HintPath>
     </Reference>
     <Reference Include="Zlib.Portable, Version=1.11.0.0, Culture=neutral, PublicKeyToken=431cba815f6a8b5b, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Zlib.Portable.Signed.1.11.0\lib\portable-net4+sl5+wp8+win8+wpa81+MonoTouch+MonoAndroid\Zlib.Portable.dll</HintPath>

--- a/PoGo.NecroBot.Logic/packages.config
+++ b/PoGo.NecroBot.Logic/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AeroWizard" version="2.1.10" targetFramework="net462" />
-  <package id="CloudFlareUtilities" version="0.2.1-alpha" targetFramework="net462" />
-  <package id="EngineIoClientDotNet" version="0.9.22" targetFramework="net462" />
+  <package id="CloudFlareUtilities" version="0.4.0-alpha" targetFramework="net462" />
+  <package id="EngineIoClientDotNet" version="0.10.1-beta2" targetFramework="net462" />
   <package id="EPPlus" version="4.1.0" targetFramework="net462" />
   <package id="Geocoding.net" version="3.6.0" targetFramework="net462" />
   <package id="GeoCoordinate.NetStandard1" version="1.0.1" targetFramework="net462" />
@@ -35,14 +35,15 @@
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net462" />
   <package id="Newtonsoft.Json.Schema" version="2.0.11" targetFramework="net462" />
   <package id="Portable.BouncyCastle" version="1.8.1.2" targetFramework="net462" />
-  <package id="Remotion.Linq" version="2.1.1" targetFramework="net462" />
+  <package id="Remotion.Linq" version="2.2.0-alpha-002" targetFramework="net462" />
   <package id="S2Geometry" version="1.0.3" targetFramework="net462" />
   <package id="Selenium.Support" version="3.4.0" targetFramework="net462" />
   <package id="Selenium.WebDriver" version="3.4.0" targetFramework="net462" />
   <package id="Selenium.WebDriver.ChromeDriver" version="2.29.0" targetFramework="net462" />
-  <package id="SocketIoClientDotNet" version="0.9.13" targetFramework="net462" />
+  <package id="SocketIoClientDotNet" version="0.10.0-beta1" targetFramework="net462" />
   <package id="SQLite" version="3.13.0" targetFramework="net462" />
   <package id="SuperSocket" version="1.6.6.1" targetFramework="net462" />
+  <package id="SuperSocket.ClientEngine.Core" version="0.8.0.10" targetFramework="net462" />
   <package id="SuperSocket.Engine" version="1.6.6.1" targetFramework="net462" />
   <package id="SuperSocket.WebSocket" version="1.6.6.1" targetFramework="net462" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net462" />
@@ -52,7 +53,7 @@
   <package id="System.ComponentModel" version="4.3.0" targetFramework="net462" />
   <package id="System.Console" version="4.3.0" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net462" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net462" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25214-03" targetFramework="net462" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net462" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net462" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net462" />
@@ -67,7 +68,9 @@
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net462" />
   <package id="System.Linq.Queryable" version="4.3.0" targetFramework="net462" />
   <package id="System.Net.Http" version="4.3.1" targetFramework="net462" />
+  <package id="System.Net.NameResolution" version="4.3.0" targetFramework="net462" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net462" />
+  <package id="System.Net.Security" version="4.3.0" targetFramework="net462" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="net462" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net462" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net462" />
@@ -93,9 +96,9 @@
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net462" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net462" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net462" />
-  <package id="Telegram.Bot" version="10.4.0" targetFramework="net462" />
+  <package id="Telegram.Bot" version="12.0.0-beta-02" targetFramework="net462" />
   <package id="TinyIoC" version="1.3" targetFramework="net462" developmentDependency="true" />
-  <package id="WebSocket4Net" version="0.14.1" targetFramework="net462" />
+  <package id="WebSocket4Net" version="0.15.0-beta7" targetFramework="net462" />
   <package id="WebSocketSharp" version="1.0.3-rc11" targetFramework="net462" />
   <package id="Zlib.Portable.Signed" version="1.11.0" targetFramework="net462" />
 </packages>

--- a/PoGo.NecroBot.Logic/packages.config
+++ b/PoGo.NecroBot.Logic/packages.config
@@ -96,7 +96,7 @@
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net462" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net462" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net462" />
-  <package id="Telegram.Bot" version="12.0.0-beta-02" targetFramework="net462" />
+  <package id="Telegram.Bot" version="10.4.0" targetFramework="net462" />
   <package id="TinyIoC" version="1.3" targetFramework="net462" developmentDependency="true" />
   <package id="WebSocket4Net" version="0.15.0-beta7" targetFramework="net462" />
   <package id="WebSocketSharp" version="1.0.3-rc11" targetFramework="net462" />

--- a/PoGo.Necrobot.Window/PoGo.Necrobot.Window.csproj
+++ b/PoGo.Necrobot.Window/PoGo.Necrobot.Window.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -141,8 +141,8 @@
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="MahApps.Metro, Version=1.5.0.23, Culture=neutral, PublicKeyToken=f4fb5a3c4d1e5b4f, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\MahApps.Metro.1.5.0\lib\net45\MahApps.Metro.dll</HintPath>
+    <Reference Include="MahApps.Metro, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\MahApps.Metro.1.6.0-alpha001\lib\net45\MahApps.Metro.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.EntityFrameworkCore, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Microsoft.EntityFrameworkCore.1.1.1\lib\net451\Microsoft.EntityFrameworkCore.dll</HintPath>
@@ -171,9 +171,23 @@
     <Reference Include="Microsoft.Extensions.Primitives, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Microsoft.Extensions.Primitives.1.1.0\lib\netstandard1.0\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\Microsoft.VisualStudio.Shell.Immutable.10.0.10.0.30319\lib\net40\Microsoft.VisualStudio.Shell.Immutable.10.0.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\Microsoft.VisualStudio.CoreUtility.15.0.25726-Preview5\lib\net45\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>$(SolutionDir)\packages\Microsoft.VisualStudio.OLE.Interop.7.10.6070\lib\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\Microsoft.VisualStudio.Shell.Framework.15.0.25726-Preview5\lib\net45\Microsoft.VisualStudio.Shell.Framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\Microsoft.VisualStudio.Shell.Immutable.10.0.15.0.25413-Preview5\lib\net40\Microsoft.VisualStudio.Shell.Immutable.10.0.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Utilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\Microsoft.VisualStudio.Utilities.15.0.25726-Preview5\lib\net45\Microsoft.VisualStudio.Utilities.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
@@ -181,8 +195,8 @@
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\Remotion.Linq.2.1.1\lib\net45\Remotion.Linq.dll</HintPath>
+    <Reference Include="Remotion.Linq, Version=2.2.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\Remotion.Linq.2.2.0-alpha-002\lib\net45\Remotion.Linq.dll</HintPath>
     </Reference>
     <Reference Include="S2Geometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\S2Geometry.1.0.3\lib\portable-net45+wp8+win8\S2Geometry.dll</HintPath>
@@ -218,8 +232,8 @@
       <HintPath>$(SolutionDir)\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
     </Reference>
     <Reference Include="System.Data" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25214-03\lib\net461\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Diagnostics.Tracing, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\System.Diagnostics.Tracing.4.3.0\lib\net462\System.Diagnostics.Tracing.dll</HintPath>
@@ -291,7 +305,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\MahApps.Metro.1.5.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\MahApps.Metro.1.6.0-alpha001\lib\net45\System.Windows.Interactivity.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />

--- a/PoGo.Necrobot.Window/PoGo.Necrobot.Window.csproj
+++ b/PoGo.Necrobot.Window/PoGo.Necrobot.Window.csproj
@@ -172,14 +172,14 @@
       <HintPath>$(SolutionDir)\packages\Microsoft.Extensions.Primitives.1.1.0\lib\netstandard1.0\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\Microsoft.VisualStudio.CoreUtility.15.0.25726-Preview5\lib\net45\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\Microsoft.VisualStudio.CoreUtility.15.0.26201\lib\net45\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>$(SolutionDir)\packages\Microsoft.VisualStudio.OLE.Interop.7.10.6070\lib\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\Microsoft.VisualStudio.Shell.Framework.15.0.25726-Preview5\lib\net45\Microsoft.VisualStudio.Shell.Framework.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\Microsoft.VisualStudio.Shell.Framework.15.0.26201\lib\net45\Microsoft.VisualStudio.Shell.Framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -187,7 +187,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Utilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\Microsoft.VisualStudio.Utilities.15.0.25726-Preview5\lib\net45\Microsoft.VisualStudio.Utilities.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\Microsoft.VisualStudio.Utilities.15.0.26201\lib\net45\Microsoft.VisualStudio.Utilities.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>

--- a/PoGo.Necrobot.Window/packages.config
+++ b/PoGo.Necrobot.Window/packages.config
@@ -8,7 +8,7 @@
   <package id="GMap.NET.Presentation" version="1.7.5" targetFramework="net462" />
   <package id="Google.Protobuf" version="3.3.0" targetFramework="net462" />
   <package id="log4net" version="2.0.8" targetFramework="net462" />
-  <package id="MahApps.Metro" version="1.5.0" targetFramework="net462" />
+  <package id="MahApps.Metro" version="1.6.0-alpha001" targetFramework="net462" />
   <package id="MahApps.Metro.Resources" version="0.6.1.0" targetFramework="net462" />
   <package id="Microsoft.EntityFrameworkCore" version="1.1.1" targetFramework="net462" />
   <package id="Microsoft.Extensions.Caching.Abstractions" version="1.1.1" targetFramework="net462" />
@@ -20,11 +20,15 @@
   <package id="Microsoft.Extensions.Options" version="1.1.1" targetFramework="net462" />
   <package id="Microsoft.Extensions.Primitives" version="1.1.0" targetFramework="net462" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net462" />
-  <package id="Microsoft.VisualStudio.Shell.Immutable.10.0" version="10.0.30319" targetFramework="net462" />
+  <package id="Microsoft.VisualStudio.CoreUtility" version="15.0.25726-Preview5" targetFramework="net462" />
+  <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6070" targetFramework="net462" />
+  <package id="Microsoft.VisualStudio.Shell.Framework" version="15.0.25726-Preview5" targetFramework="net462" />
+  <package id="Microsoft.VisualStudio.Shell.Immutable.10.0" version="15.0.25413-Preview5" targetFramework="net462" />
+  <package id="Microsoft.VisualStudio.Utilities" version="15.0.25726-Preview5" targetFramework="net462" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net462" />
-  <package id="Remotion.Linq" version="2.1.1" targetFramework="net462" />
+  <package id="Remotion.Linq" version="2.2.0-alpha-002" targetFramework="net462" />
   <package id="S2Geometry" version="1.0.3" targetFramework="net462" />
   <package id="Selenium.WebDriver.ChromeDriver" version="2.29.0" targetFramework="net462" />
   <package id="SuperSocket" version="1.6.6.1" targetFramework="net462" />
@@ -36,7 +40,7 @@
   <package id="System.ComponentModel" version="4.3.0" targetFramework="net462" />
   <package id="System.Console" version="4.3.0" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net462" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net462" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25214-03" targetFramework="net462" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net462" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net462" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net462" />

--- a/PoGo.Necrobot.Window/packages.config
+++ b/PoGo.Necrobot.Window/packages.config
@@ -20,11 +20,11 @@
   <package id="Microsoft.Extensions.Options" version="1.1.1" targetFramework="net462" />
   <package id="Microsoft.Extensions.Primitives" version="1.1.0" targetFramework="net462" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net462" />
-  <package id="Microsoft.VisualStudio.CoreUtility" version="15.0.25726-Preview5" targetFramework="net462" />
+  <package id="Microsoft.VisualStudio.CoreUtility" version="15.0.26201" targetFramework="net462" />
   <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6070" targetFramework="net462" />
-  <package id="Microsoft.VisualStudio.Shell.Framework" version="15.0.25726-Preview5" targetFramework="net462" />
+  <package id="Microsoft.VisualStudio.Shell.Framework" version="15.0.26201" targetFramework="net462" />
   <package id="Microsoft.VisualStudio.Shell.Immutable.10.0" version="15.0.25413-Preview5" targetFramework="net462" />
-  <package id="Microsoft.VisualStudio.Utilities" version="15.0.25726-Preview5" targetFramework="net462" />
+  <package id="Microsoft.VisualStudio.Utilities" version="15.0.26201" targetFramework="net462" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net462" />

--- a/RocketBot2/Helpers/Options.cs
+++ b/RocketBot2/Helpers/Options.cs
@@ -11,20 +11,20 @@ namespace RocketBot2.Helpers
             HelpText = "Init account")]
           public bool Init { get; set; }
 
-          [Option('t', "template", DefaultValue = "", Required = false, HelpText = "Prints all messages to standard output.")]
+          [Option('t', "template", Default = "", Required = false, HelpText = "Prints all messages to standard output.")]
           public string Template { get; set; }
 
-          [Option('p', "password", DefaultValue = "", Required = false, HelpText = "pasword")]
+          [Option('p', "password", Default = "", Required = false, HelpText = "pasword")]
           public string Password { get; set; }
 
-          [Option('g', "google", DefaultValue = false, Required = false, HelpText = "is google account")]
+          [Option('g', "google", Default = false, Required = false, HelpText = "is google account")]
           public bool IsGoogle { get; set; }
 
-          [Option('s', "start", DefaultValue = 1, HelpText = "Start account", Required = false)]
+          [Option('s', "start", Default = 1, HelpText = "Start account", Required = false)]
           public int Start { get; set; }
 
 
-          [Option('e', "end", DefaultValue = 10, HelpText = "End account", Required = false)]
+          [Option('e', "end", Default = 10, HelpText = "End account", Required = false)]
           public int End { get; set; }
 
           [ParserState]

--- a/RocketBot2/RocketBot2.csproj
+++ b/RocketBot2/RocketBot2.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -115,6 +115,9 @@
     <Reference Include="AeroWizard, Version=2.1.10.0, Culture=neutral, PublicKeyToken=915e74f5d64b8f37, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\AeroWizard.2.1.10\lib\net452\AeroWizard.dll</HintPath>
     </Reference>
+    <Reference Include="CommandLine, Version=2.0.275.0, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\CommandLineParser.2.1.1-beta\lib\net45\CommandLine.dll</HintPath>
+    </Reference>
     <Reference Include="GeoCoordinate.NetStandard1, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\GeoCoordinate.NetStandard1.1.0.1\lib\netstandard1.1\GeoCoordinate.NetStandard1.dll</HintPath>
     </Reference>
@@ -161,8 +164,11 @@
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\Remotion.Linq.2.1.1\lib\net45\Remotion.Linq.dll</HintPath>
+    <Reference Include="ObjectListView, Version=2.9.1.25410, Culture=neutral, PublicKeyToken=b1c5bf581481bcd4, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\ObjectListView.Official.2.9.2-alpha2\lib\net20\ObjectListView.dll</HintPath>
+    </Reference>
+    <Reference Include="Remotion.Linq, Version=2.2.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\Remotion.Linq.2.2.0-alpha-002\lib\net45\Remotion.Linq.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -180,8 +186,8 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\System.Diagnostics.DiagnosticSource.4.4.0-preview1-25214-03\lib\net461\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Diagnostics.Tracing, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\System.Diagnostics.Tracing.4.3.0\lib\net462\System.Diagnostics.Tracing.dll</HintPath>
@@ -219,6 +225,9 @@
     <Reference Include="System.Reflection, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\System.Reflection.4.3.0\lib\net462\System.Reflection.dll</HintPath>
     </Reference>
+    <Reference Include="System.Reflection.TypeExtensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\System.Reflection.TypeExtensions.4.1.0-rc2-24027\lib\net462\System.Reflection.TypeExtensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
     </Reference>
@@ -247,10 +256,6 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="CommandLine, Version=1.9.71.2, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="GMap.NET.Core, Version=1.7.5.0, Culture=neutral, PublicKeyToken=b85b9027b614afef, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\GMap.NET.WindowsForms.1.7.5\lib\net40\GMap.NET.Core.dll</HintPath>
       <Private>True</Private>
@@ -277,10 +282,6 @@
     </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="ObjectListView, Version=2.9.1.1072, Culture=neutral, PublicKeyToken=b1c5bf581481bcd4, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\ObjectListView.Official.2.9.1\lib\net20\ObjectListView.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="S2Geometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/RocketBot2/RocketBot2.csproj
+++ b/RocketBot2/RocketBot2.csproj
@@ -225,8 +225,8 @@
     <Reference Include="System.Reflection, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\System.Reflection.4.3.0\lib\net462\System.Reflection.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.TypeExtensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\System.Reflection.TypeExtensions.4.1.0-rc2-24027\lib\net462\System.Reflection.TypeExtensions.dll</HintPath>
+    <Reference Include="System.Reflection.TypeExtensions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\System.Reflection.TypeExtensions.4.3.0\lib\net462\System.Reflection.TypeExtensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>

--- a/RocketBot2/packages.config
+++ b/RocketBot2/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AeroWizard" version="2.1.10" targetFramework="net462" />
-  <package id="CommandLineParser" version="1.9.71" targetFramework="net462" />
+  <package id="CommandLineParser" version="2.1.1-beta" targetFramework="net462" />
   <package id="Costura.Fody" version="1.4.1" targetFramework="net462" developmentDependency="true" />
   <package id="Fody" version="2.0.7" targetFramework="net462" developmentDependency="true" />
   <package id="GeoCoordinate.NetStandard1" version="1.0.1" targetFramework="net462" />
@@ -21,8 +21,8 @@
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net462" />
-  <package id="ObjectListView.Official" version="2.9.1" targetFramework="net462" />
-  <package id="Remotion.Linq" version="2.1.1" targetFramework="net462" />
+  <package id="ObjectListView.Official" version="2.9.2-alpha2" targetFramework="net462" />
+  <package id="Remotion.Linq" version="2.2.0-alpha-002" targetFramework="net462" />
   <package id="S2Geometry" version="1.0.3" targetFramework="net462" />
   <package id="Selenium.Support" version="3.4.0" targetFramework="net462" />
   <package id="Selenium.WebDriver" version="3.4.0" targetFramework="net462" />
@@ -36,7 +36,7 @@
   <package id="System.ComponentModel" version="4.3.0" targetFramework="net462" />
   <package id="System.Console" version="4.3.0" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net462" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net462" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0-preview1-25214-03" targetFramework="net462" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net462" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net462" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net462" />
@@ -57,6 +57,7 @@
   <package id="System.Reflection" version="4.3.0" targetFramework="net462" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net462" />
   <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net462" />
+  <package id="System.Reflection.TypeExtensions" version="4.1.0-rc2-24027" targetFramework="net462" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net462" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net462" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.3.0" targetFramework="net462" />

--- a/RocketBot2/packages.config
+++ b/RocketBot2/packages.config
@@ -57,7 +57,7 @@
   <package id="System.Reflection" version="4.3.0" targetFramework="net462" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net462" />
   <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net462" />
-  <package id="System.Reflection.TypeExtensions" version="4.1.0-rc2-24027" targetFramework="net462" />
+  <package id="System.Reflection.TypeExtensions" version="4.3.0" targetFramework="net462" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net462" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net462" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.3.0" targetFramework="net462" />


### PR DESCRIPTION
CommandLineParser: v1.9.71 to v2.1.1 (Beta)
ObjectListView: v2.9.1 to v2.9.2 (Alpha 2)
Remotion.Linq: v2.1.1 to v2.2.0 (Alpha 002)
System.Diagnostics.DiagnosticSource: v4.3.0 to v4.4.0 (Preview 1)
MahApps.Metro: v1.5.0 to v1.6.0 (Alpha 001)
Microsoft.VS.Shell.Immutable: v10.0.30319 to v15.0.25726 (Preview 5)
CloudFlareUtilities: v0.2.1 (Alpha) to v0.4.0 (Alpha)
EngineIoClientDotNet: v0.9.22 to v0.10.1 (Beta 2)
SocketIoClientDotNet: v0.9.13 to v0.10.0 (Beta 1)
System.Reflection.TypeExtensions: v4.1.0 to v4.3.0
MSFT.VS.Core/Shell/Utilities: v15.0.25726 to v15.0.26201
WebSocket4Net: v0.14.1 to v0.15.0 (Beta 7)

Signed-off-by: CDAGaming <cstack2011@yahoo.com>

*This is an OPTIONAL PR, so it can be closed if not satisfactory*
