### PR TITLE
Bug fix/local sniping

### DIFF
--- a/PoGo.NecroBot.Logic/Model/Settings/SnipeConfig.cs
+++ b/PoGo.NecroBot.Logic/Model/Settings/SnipeConfig.cs
@@ -119,7 +119,7 @@ namespace PoGo.NecroBot.Logic.Model.Settings
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 25)]
         public int SnipePauseOnOutOfBallTime { get;  set; }
 
-        [NecrobotConfig(Description = "Max distance in km that will allow bot to auto snipe. set to Z mean not applied", Position = 26)]
+        [NecrobotConfig(Description = "Max distance in km that will allow bot to auto snipe.", Position = 26)]
         [DefaultValue(0)]
         [JsonProperty(Required = Required.DisallowNull, DefaultValueHandling = DefaultValueHandling.Populate, Order = 26)]
         public double AutoSnipeMaxDistance { get;  set; }

--- a/PoGo.NecroBot.Logic/Service/BotDataSocketClient.cs
+++ b/PoGo.NecroBot.Logic/Service/BotDataSocketClient.cs
@@ -20,6 +20,8 @@ using System.Reflection;
 using TinyIoC;
 using static PoGo.NecroBot.Logic.Service.AnalyticsService;
 using Pogo;
+using PoGo.NecroBot.Logic.Utils;
+using GeoCoordinatePortable;
 
 namespace PoGo.NecroBot.Logic.Service
 {
@@ -87,6 +89,10 @@ namespace PoGo.NecroBot.Logic.Service
         public static async Task HandleEvent(AnalyticsEvent e, ISession session)
         {
             Pokemon data = e.Data as Pokemon;
+            var distance = LocationUtils.CalculateDistanceInMeters(new GeoCoordinate(session.Client.CurrentLatitude, session.Client.CurrentLongitude), new GeoCoordinate(data.Latitude, data.Longitude));
+            if (distance > 100000)
+                return;
+            
             switch (e.EventType)
             {
                 case 1:
@@ -407,6 +413,10 @@ namespace PoGo.NecroBot.Logic.Service
                 {
                     return;
                 };
+
+                var distance = LocationUtils.CalculateDistanceInMeters(new GeoCoordinate(session.Client.CurrentLatitude, session.Client.CurrentLongitude), new GeoCoordinate(data.Latitude, data.Longitude));
+                if (distance > 100000)
+                    return;
 
                 ulong.TryParse(data.EncounterId, out ulong encounterid);
                 if (encounterid > 0 && cache.Get(encounterid.ToString()) == null)

--- a/PoGo.NecroBot.Logic/Service/BotDataSocketClient.cs
+++ b/PoGo.NecroBot.Logic/Service/BotDataSocketClient.cs
@@ -90,7 +90,8 @@ namespace PoGo.NecroBot.Logic.Service
         {
             Pokemon data = e.Data as Pokemon;
             var distance = LocationUtils.CalculateDistanceInMeters(new GeoCoordinate(session.Client.CurrentLatitude, session.Client.CurrentLongitude), new GeoCoordinate(data.Latitude, data.Longitude));
-            if (distance > 100000)
+            var maxDistance = session.LogicSettings.EnableHumanWalkingSnipe ? (session.LogicSettings.HumanWalkingSnipeMaxDistance > 0 ? session.LogicSettings.HumanWalkingSnipeMaxDistance : 1500) : 10000;
+            if (distance > maxDistance)
                 return;
             
             switch (e.EventType)
@@ -415,7 +416,8 @@ namespace PoGo.NecroBot.Logic.Service
                 };
 
                 var distance = LocationUtils.CalculateDistanceInMeters(new GeoCoordinate(session.Client.CurrentLatitude, session.Client.CurrentLongitude), new GeoCoordinate(data.Latitude, data.Longitude));
-                if (distance > 100000)
+                var maxDistance = session.LogicSettings.EnableHumanWalkingSnipe ? (session.LogicSettings.HumanWalkingSnipeMaxDistance > 0 ? session.LogicSettings.HumanWalkingSnipeMaxDistance : 1500) : 10000;
+                if (distance > maxDistance)
                     return;
 
                 ulong.TryParse(data.EncounterId, out ulong encounterid);

--- a/PoGo.NecroBot.Logic/State/BotSwitcherState.cs
+++ b/PoGo.NecroBot.Logic/State/BotSwitcherState.cs
@@ -35,7 +35,7 @@ namespace PoGo.NecroBot.Logic.State
             else
             {
                 //snipe pokemon 
-                await MSniperServiceTask.CatchFromService(session, session.CancellationTokenSource.Token, new MSniperServiceTask.MSniperInfo2()
+                await MSniperServiceTask.CatchWithSnipe(session, new MSniperServiceTask.MSniperInfo2()
                 {
                     AddedTime = DateTime.Now,
                     Latitude = encounterData.Latitude, 
@@ -44,7 +44,7 @@ namespace PoGo.NecroBot.Logic.State
                     PokemonId =(short)encounterData.PokemonId,
                     SpawnPointId = encounterData.SpawnPointId,
                     EncounterId = Convert.ToUInt64(encounterData.EncounterId)
-                }).ConfigureAwait(false);
+                }, session.CancellationTokenSource.Token).ConfigureAwait(false);
             }
             return new InfoState();
         }

--- a/PoGo.NecroBot.Logic/Tasks/MSniperServiceTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/MSniperServiceTask.cs
@@ -397,7 +397,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             }
         }
 
-        public static async Task<bool> SnipeUnverifiedPokemon(ISession session, MSniperInfo2 sniperInfo, CancellationToken cancellationToken, bool useWalk = true)
+        public static async Task<bool> SnipeUnverifiedPokemon(ISession session, MSniperInfo2 sniperInfo, CancellationToken cancellationToken)
         {
             var latitude = sniperInfo.Latitude;
             var longitude = sniperInfo.Longitude;
@@ -411,7 +411,9 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             MapPokemon catchablePokemon;
             int retry = 3;
-            
+
+            bool useWalk = session.LogicSettings.EnableHumanWalkingSnipe;
+
             try
             {
                 var distance = LocationUtils.CalculateDistanceInMeters(new GeoCoordinate(session.Client.CurrentLatitude, session.Client.CurrentLongitude), new GeoCoordinate(latitude, longitude));
@@ -425,11 +427,11 @@ namespace PoGo.NecroBot.Logic.Tasks
                             async () =>
                             {
                                 cancellationToken.ThrowIfCancellationRequested();
-                                await ActionsWhenTravelToSnipeTarget(session, cancellationToken, new MapLocation(latitude, longitude, 0), false, false).ConfigureAwait(false);
+                                await ActionsWhenTravelToSnipeTarget(session, cancellationToken, new MapLocation(latitude, longitude, 0), session.LogicSettings.HumanWalkingSnipeCatchPokemonWhileWalking, session.LogicSettings.HumanWalkingSnipeSpinWhileWalking).ConfigureAwait(false);
                             },
                             session,
                             cancellationToken,
-                            200
+                            session.LogicSettings.HumanWalkingSnipeAllowSpeedUp ? session.LogicSettings.HumanWalkingSnipeMaxSpeedUpSpeed : 200
                         ).ConfigureAwait(false);
                 }
                 else
@@ -558,11 +560,11 @@ namespace PoGo.NecroBot.Logic.Tasks
                         async () =>
                         {
                             cancellationToken.ThrowIfCancellationRequested();
-                            await ActionsWhenTravelToSnipeTarget(session, cancellationToken, new MapLocation(latitude, longitude, 0), false, false).ConfigureAwait(false);
+                            await ActionsWhenTravelToSnipeTarget(session, cancellationToken, new MapLocation(latitude, longitude, 0), session.LogicSettings.HumanWalkingSnipeCatchPokemonWhileWalking, session.LogicSettings.HumanWalkingSnipeSpinWhileWalking).ConfigureAwait(false);
                         },
                         session,
                         cancellationToken,
-                        200
+                        session.LogicSettings.HumanWalkingSnipeAllowSpeedUp ? session.LogicSettings.HumanWalkingSnipeMaxSpeedUpSpeed : 200
                     ).ConfigureAwait(false);
                 }
                 else


### PR DESCRIPTION
## Short Description:
Sniping is back!  This pull implements short range sniping (auto sniping works as well as manual sniping from the Win.GUI sniper).  Here's how it works:

1) We are still feeding our bots with data from our sniping server.  However, only pokemon within a small range will be processed and added to the sniping lists.  This range is configurable (see below).
2) There are 2 movement options for sniping: a) Teleporting, and b) Walking.  
3) Teleporting MAY result in catch flee when encountering the pokemon.  This seems to be dependent on how far the jump is. Teleporting may also not be that much faster - you may notice a long pause (up to 30 seconds) after the jump. This is due to the bot refreshing the map and waiting for the teleport softban to expire.
4) Walking is always reliable but obviously takes some time to walk to the target.  There are several options for walking: a) Catching other pokemon while walking, b) Spinning pokestops while walking, c) Speed up your walking speed (higher than your "normal" walking speed).

The settings that the auto sniper is checking:

"HumanWalkSnipeConfig": {
    "Enable": true,
    "MaxDistance": 1500.0,
    "CatchPokemonWhileWalking": true,
    "SpinWhileWalking": true,
    "MaxSpeedUpSpeed": 60.0,
    "AllowSpeedUp": true,
  },

If `HumanWalkSnipeConfig.Enable` is true, then we'll walk to the snipe target. Otherwise we do a teleport like before.  Note that yo may frequently get catch flee when catching pokemon after teleport due to Niantic's new serverside checks on distance.

`HumanWalkSnipeConfig.MaxDistance` will determine which pokemon show up for sniping. Only pokemon within this range will be snipable.

`HumanWalkSnipeConfig.CatchPokemonWhileWalking` will allow you to catch other pokemon while walking to your snipe target.

`HumanWalkSnipeConfig.SpinWhileWalking` will allow you to spin pokestops while walking to your snipe target.

`HumanWalkSnipeConfig.AllowSpeedUp` allows you to increase walking speed when moving to sniping target.

`HumanWalkSnipeConfig.MaxSpeedUpSpeed` is the max speed when using the `AllowSpeedUp` option.

In my limited experience testing the settings, a sniping configuration with a `MaxSpeedUpSpeed` of around 200 is working pretty well.  I'm curious to have people play with this and share what the best `MaxSpeedUpSpeed` speed is before the softban starts to slow things down.