### PR TITLE
Fix ConsoleThemer Border & Add 3-Way Color Support (WIP)

### DIFF
--- a/PoGo.Necrobot.Window/MainClientWindow.xaml
+++ b/PoGo.Necrobot.Window/MainClientWindow.xaml
@@ -222,7 +222,7 @@
                   </Grid.ColumnDefinitions>
                   <TextBox x:Name="txtCmdInput" Grid.Column="0" ToolTip="{Binding Source=InputCommand, Converter={StaticResource ResourceKey=I18NConveter}}" MouseDown="TxtCmdInput_MouseDown" KeyDown="TxtCmdInput_KeyDown" />
                   <GridSplitter Grid.Column="1" />
-                  <ComboBox x:Name="ConsoleThemer" Grid.Column="2" IsEditable="False" IsReadOnly="True" SelectionChanged="ConsoleThemer_SelectionChanged" BorderBrush="{x:Null}" ToolTip="Set Console Colors" />
+                  <ComboBox x:Name="ConsoleThemer" Grid.Column="2" IsEditable="False" IsReadOnly="True" SelectionChanged="ConsoleThemer_SelectionChanged" BorderBrush="#FFCCCCCC" ToolTip="Set Console Colors" />
                 </Grid>
                 <RichTextBox ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.CanContentScroll="True" DockPanel.Dock="Bottom" x:Name="consoleLog" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontSize="15" IsReadOnly="True" FontFamily="/NecroBot2.Win;component/Resources/Fonts/Lato/#Lato Light">
                   <FlowDocument>

--- a/PoGo.Necrobot.Window/MainClientWindow.xaml.cs
+++ b/PoGo.Necrobot.Window/MainClientWindow.xaml.cs
@@ -42,29 +42,29 @@ namespace PoGo.Necrobot.Window
         BrowserView webView;
 
         Timer timer = new Timer();
-        private static Dictionary<LogLevel, Tuple<string, string>> ConsoleColors = new Dictionary<LogLevel, Tuple<string, string>>()
+        private static Dictionary<LogLevel, Tuple<string, string, string>> ConsoleColors = new Dictionary<LogLevel, Tuple<string, string, string>>()
         {
-            // Console Colors <Default, Solarized>
-                { LogLevel.Error, new Tuple<string, string>("Red", "#DC322F") },
-                { LogLevel.Caught, new Tuple<string, string>("Green", "#859900") },
-                { LogLevel.Info, new Tuple<string, string>("DarkCyan", "#CB4B16") },
-                { LogLevel.Warning, new Tuple<string, string>("DarkYellow", "#B58900") },
-                { LogLevel.Pokestop, new Tuple<string, string>("Cyan", "#2AA198") },
-                { LogLevel.Farming, new Tuple<string, string>("Magenta", "#D33682") },
-                { LogLevel.Sniper, new Tuple<string, string>("White", "#657b83") },
-                { LogLevel.Recycling, new Tuple<string, string>("DarkMagenta", "#6C71C4") },
-                { LogLevel.Flee, new Tuple<string, string>("DarkYellow", "#B58900") },
-                { LogLevel.Transfer, new Tuple<string, string>("DarkGreen", "#268BD2") },
-                { LogLevel.Evolve, new Tuple<string, string>("DarkGreen", "#268BD2") },
-                { LogLevel.Berry, new Tuple<string, string>("DarkYellow", "#B58900") },
-                { LogLevel.Egg, new Tuple<string, string>("DarkYellow", "#B58900") },
-                { LogLevel.Debug, new Tuple<string, string>("Gray", "#93A1A1") },
-                { LogLevel.Update, new Tuple<string, string>("White", "#657B83") },
-                { LogLevel.New, new Tuple<string, string>("Green", "#859900") },
-                { LogLevel.SoftBan, new Tuple<string, string>("Red", "#DC322F") },
-                { LogLevel.LevelUp, new Tuple<string, string>("Magenta", "#D33682") },
-                { LogLevel.Gym, new Tuple<string, string>("Magenta", "#D33682") },
-                { LogLevel.Service , new Tuple<string, string>("White", "#657b83") }
+            // Console Colors <Default, Solarized_Dark, Solarized_Light>
+                { LogLevel.Error, new Tuple<string, string, string>("Pink", "#FF1E8E", "") },
+                { LogLevel.Caught, new Tuple<string, string, string>("Green", "#83FF08", "") },
+                { LogLevel.Info, new Tuple<string, string, string>("Green", "#83FF08", "") },
+                { LogLevel.Warning, new Tuple<string, string, string>("Orange", "#FF8308", "") },
+                { LogLevel.Pokestop, new Tuple<string, string, string>("Cyan", "#B4E1FD", "") },
+                { LogLevel.Farming, new Tuple<string, string, string>("Green", "#83FF08", "") },
+                { LogLevel.Sniper, new Tuple<string, string, string>("Grey", "#B6B6B6", "") },
+                { LogLevel.Recycling, new Tuple<string, string, string>("Grey", "#B6B6B6", "") },
+                { LogLevel.Flee, new Tuple<string, string, string>("Purple", "#8308FF", "") },
+                { LogLevel.Transfer, new Tuple<string, string, string>("Grey", "#B6B6B6", "") },
+                { LogLevel.Evolve, new Tuple<string, string, string>("Cyan", "#B4E1FD", "") },
+                { LogLevel.Berry, new Tuple<string, string, string>("Orange", "#FF8308", "") },
+                { LogLevel.Egg, new Tuple<string, string, string>("Cyan", "#B4E1FD", "") },
+                { LogLevel.Debug, new Tuple<string, string, string>("Grey", "#B6B6B6", "") },
+                { LogLevel.Update, new Tuple<string, string, string>("Blue", "#0883FF", "") },
+                { LogLevel.New, new Tuple<string, string, string>("Blue", "#0883FF", "") },
+                { LogLevel.SoftBan, new Tuple<string, string, string>("Pink", "#FF1E8E", "") },
+                { LogLevel.LevelUp, new Tuple<string, string, string>("Blue", "#0883FF", "") },
+                { LogLevel.Gym, new Tuple<string, string, string>("Purple", "#8308FF", "") },
+                { LogLevel.Service , new Tuple<string, string, string>("Grey", "#B6B6B6", "") }
         };
 
         private static SolidColorBrush DarkSolarizedBackground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#002B36"));
@@ -214,6 +214,7 @@ namespace PoGo.Necrobot.Window
                 ConsoleHelper.HideConsoleWindow();
                 Settings.Default.ConsoleText = "Show Console";
             }
+            Settings.Default.Save();
         }
 
         public void ResetSync()
@@ -239,7 +240,9 @@ namespace PoGo.Necrobot.Window
         private DateTime lastClearLog = DateTime.Now;
         public void LogToConsoleTab(string message, LogLevel level, string color)
         {
-            if (Settings.Default.ConsoleTheme != "Default")
+            if (Settings.Default.ConsoleTheme == "Low Contrast (Light)")
+                color = ConsoleColors[level].Item3;
+            if (Settings.Default.ConsoleTheme == "Low Contrast (Dark)")
                 color = ConsoleColors[level].Item2;
             else if (Settings.Default.ConsoleTheme == "Default" || Settings.Default.ResetLayout == true)
                 color = ConsoleColors[level].Item1;
@@ -296,7 +299,6 @@ namespace PoGo.Necrobot.Window
             else if (Settings.Default.ConsoleToggled == false)
                 Settings.Default.ConsoleToggled = true;
             Settings.Default.Save();
-            Settings.Default.Reload();
             ConsoleSync();
         }
 


### PR DESCRIPTION
Signed-off-by: CDAGaming <cstack2011@yahoo.com>

This PR Adds Support for Specific Colors for Light,Dark, and Default. It also sets the ConsoleThemer Border to a Default Color to match the bar itself