### PR TITLE
Many Bug Fixes & General Improvements - Ready to Merge!

### DIFF
--- a/PoGo.NecroBot.CLI/PoGo.NecroBot.CLI.csproj
+++ b/PoGo.NecroBot.CLI/PoGo.NecroBot.CLI.csproj
@@ -478,7 +478,7 @@ rmdir /s /q x64</PostBuildEvent>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\packages\Selenium.WebDriver.ChromeDriver.2.29.0\build\Selenium.WebDriver.ChromeDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Selenium.WebDriver.ChromeDriver.2.29.0\build\Selenium.WebDriver.ChromeDriver.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)\packages\Fody.2.0.8\build\netstandard1.4\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Fody.2.0.8\build\netstandard1.4\Fody.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\Fody.2.0.9\build\netstandard1.4\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Fody.2.0.9\build\netstandard1.4\Fody.targets'))" />
   </Target>
   <UsingTask TaskName="CosturaCleanup" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll" TaskFactory="CodeTaskFactory">
     <ParameterGroup>
@@ -517,7 +517,7 @@ foreach (var item in filesToCleanup)
     <CosturaCleanup Config="FodyWeavers.xml" Files="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename)%(Extension)')" />
   </Target>
   <Import Project="$(SolutionDir)\packages\Selenium.WebDriver.ChromeDriver.2.29.0\build\Selenium.WebDriver.ChromeDriver.targets" Condition="Exists('$(SolutionDir)\packages\Selenium.WebDriver.ChromeDriver.2.29.0\build\Selenium.WebDriver.ChromeDriver.targets')" />
-  <Import Project="$(SolutionDir)\packages\Fody.2.0.8\build\netstandard1.4\Fody.targets" Condition="Exists('$(SolutionDir)\packages\Fody.2.0.8\build\netstandard1.4\Fody.targets')" />
+  <Import Project="$(SolutionDir)\packages\Fody.2.0.9\build\netstandard1.4\Fody.targets" Condition="Exists('$(SolutionDir)\packages\Fody.2.0.9\build\netstandard1.4\Fody.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/PoGo.NecroBot.CLI/packages.config
+++ b/PoGo.NecroBot.CLI/packages.config
@@ -3,7 +3,7 @@
   <package id="AeroWizard" version="2.1.10" targetFramework="net462" />
   <package id="CommandLineParser" version="1.9.71" targetFramework="net462" />
   <package id="Costura.Fody" version="1.4.1" targetFramework="net462" developmentDependency="true" />
-  <package id="Fody" version="2.0.8" targetFramework="net462" developmentDependency="true" />
+  <package id="Fody" version="2.0.9" targetFramework="net462" developmentDependency="true" />
   <package id="Google.Protobuf" version="3.3.0" targetFramework="net462" />
   <package id="log4net" version="2.0.8" targetFramework="net462" />
   <package id="Microsoft.EntityFrameworkCore" version="1.1.2" targetFramework="net462" />

--- a/PoGo.NecroBot.Logic/Common/UITranslation.cs
+++ b/PoGo.NecroBot.Logic/Common/UITranslation.cs
@@ -11,11 +11,6 @@ namespace PoGo.NecroBot.Logic.Common
     public class UITranslation
     {
         #region Main screen
-        [Description("Bot Exit!!!")]
-        public string ErrorPopupTitle { get; set; }
-
-        [Description("CLICK HERE TO EXIT")]
-        public string ClickHereExit { get; set; }
 
         [Description("Accounts")]
         public string AccountSetting { get; set; }
@@ -28,9 +23,6 @@ namespace PoGo.NecroBot.Logic.Common
 
         [Description("Help")]
         public string Help { get; set; }
-
-        [Description("Bot Switching Account... ")]
-        public string AccountSwitching { get; set; }
 
         [Description("Show Console")]
         public string ShowConsole { get; set; }

--- a/PoGo.Necrobot.Window/App.xaml.cs
+++ b/PoGo.Necrobot.Window/App.xaml.cs
@@ -20,7 +20,6 @@ namespace PoGo.Necrobot.Window
     /// </summary>
     public partial class App : Application
     {
-        
         public App()
         {
             ShutdownMode = ShutdownMode.OnLastWindowClose;
@@ -90,6 +89,11 @@ namespace PoGo.Necrobot.Window
             {
                 NecroBot.CLI.Program.RunBotWithParameters(OnBotStartedEventHandler, new string[] { });
             });
+
+            if (Settings.Default.ConsoleToggled == true)
+                ConsoleHelper.ShowConsoleWindow();
+            if (Settings.Default.ConsoleToggled == false)
+                ConsoleHelper.HideConsoleWindow();
             
             MainWindow.Show();
         }

--- a/PoGo.Necrobot.Window/Controls/MapControl.xaml
+++ b/PoGo.Necrobot.Window/Controls/MapControl.xaml
@@ -4,22 +4,20 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:PoGo.Necrobot.Window.Controls"
-             xmlns:c="clr-namespace:PoGo.Necrobot.Window.Converters"
-                
-            xmlns:WindowsPresentation="clr-namespace:GMap.NET.WindowsPresentation;assembly=GMap.NET.WindowsPresentation" x:Class="PoGo.Necrobot.Window.Controls.MapControl"
+             xmlns:c="clr-namespace:PoGo.Necrobot.Window.Converters" 
+             xmlns:WindowsPresentation="clr-namespace:GMap.NET.WindowsPresentation;assembly=GMap.NET.WindowsPresentation"
+             x:Class="PoGo.Necrobot.Window.Controls.MapControl"
              mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="300" DataContextChanged="UserControl_DataContextChanged"
-    >
+             d:DesignHeight="300" d:DesignWidth="300" DataContextChanged="UserControl_DataContextChanged">
     <UserControl.Resources>
         <c:I18NConveter x:Key="I18NConveter"/>
     </UserControl.Resources>
-
     <DockPanel LastChildFill="True">
         <Slider Width="20" VerticalAlignment="Stretch" Minimum="{Binding ElementName=gmap, Path=MinZoom}" Maximum="{Binding ElementName=gmap, Path=MaxZoom}" Value="{Binding ElementName=gmap, Path=Zoom}" DockPanel.Dock="Right" Orientation="Vertical"  AutoToolTipPlacement="BottomRight" ></Slider>
         <Popup IsOpen="False" Name="popSelect" PopupAnimation="Scroll">
             <Border Background="GhostWhite" BorderBrush="DodgerBlue" BorderThickness="1,3,1,5">
                 <StackPanel Margin="10" Width="200">
-                    <TextBlock HorizontalAlignment="Center" FontSize="15" Foreground="RoyalBlue" FontStyle="Oblique" >
+                    <TextBlock HorizontalAlignment="Center" FontSize="15" Foreground="RoyalBlue" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Light" FontStyle="Oblique" >
                         <TextBlock.Text>
                             <MultiBinding StringFormat="{}{0:0.000000},{1:0.000000}" FallbackValue="x.xxxxx,y.yyyyy" >
                                 <Binding Path="CurrentLatitude"></Binding>
@@ -27,7 +25,7 @@
                             </MultiBinding>
                         </TextBlock.Text>
                     </TextBlock>
-                    <Button Margin="0,30,0,10" Width="100" Click="BtnWalkHere_Click" Content="{Binding Source=WalkHere, Converter={StaticResource I18NConveter}}" ></Button>
+                    <Button Margin="0,30,0,10" Width="100" Click="BtnWalkHere_Click" Content="{Binding Source=WalkHere, Converter={StaticResource I18NConveter}}" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium"></Button>
                 </StackPanel>
             </Border>
         </Popup>
@@ -39,32 +37,25 @@
                                          VerticalContentAlignment="Stretch" 
                                          HorizontalContentAlignment="Stretch" 
                                          CanDragMap="True" MouseWheelZoomType="MousePositionWithoutCenter" 
-                                         MouseLeftButtonUp="Gmap_MouseLeftButtonUp"
-                                         >
+                                         MouseLeftButtonUp="Gmap_MouseLeftButtonUp">
             <WindowsPresentation:GMapControl.ContextMenu>
                 <ContextMenu Margin="20,20,20,20">
                     <MenuItem Header="{Binding Source=ClearMap, Converter={StaticResource I18NConveter}}" Name="mnuClear" Click="MnuClear_Click" >
                         <MenuItem.Icon>
                             <Image Source="https://cdn3.iconfinder.com/data/icons/tango-icon-library/48/edit-clear-32.png" Width="28" Margin="20,5,20,5"></Image>
                         </MenuItem.Icon>
-
                     </MenuItem>
-
                     <MenuItem Header="{Binding Source=ZoomIn, Converter={StaticResource I18NConveter}}" Name="mnuZoomIn" Click="MnuZoomIn_Click" >
                         <MenuItem.Icon>
                             <Image Source="https://cdn2.iconfinder.com/data/icons/ios-7-icons/50/zoom_in-32.png" Width="28" Margin="20,5,20,5"></Image>
                         </MenuItem.Icon>
-
                     </MenuItem>
-
                     <MenuItem Header="{Binding Source=ZoomOut, Converter={StaticResource I18NConveter}}" Name="mnuZoomOut" Click="MnuZoomOut_Click" >
                         <MenuItem.Icon>
                             <Image Source="https://cdn2.iconfinder.com/data/icons/freecns-cumulus/16/519894-015_ZoomOut-32.png" Width="28" Margin="20,5,20,5"></Image>
                         </MenuItem.Icon>
-
                     </MenuItem>
                 </ContextMenu>
-
             </WindowsPresentation:GMapControl.ContextMenu>
         </WindowsPresentation:GMapControl>
     </DockPanel>

--- a/PoGo.Necrobot.Window/Controls/PlayerInfo.xaml
+++ b/PoGo.Necrobot.Window/Controls/PlayerInfo.xaml
@@ -11,22 +11,18 @@
         <c:I18NConveter x:Key="I18NConveter"></c:I18NConveter>
         <c:I18NMultiConveter x:Key="I18NMultiConveter"></c:I18NMultiConveter>
     </Control.Resources>
-    
     <DockPanel LastChildFill="True">
         <StackPanel DockPanel.Dock="Left" Width="75" Orientation="Vertical">
-            <Image  Name="image" Width="45"  Source="{Binding Path=BuddyPokemonId, FallbackValue=https://img.pokemondb.net/artwork/garchomp.jpg, Converter={StaticResource PokemonIdToImageConverter}}">
-                </Image>
-            
-                <TextBlock TextAlignment="Center">
-                    <TextBlock.Text>
-                         <MultiBinding  StringFormat="{}{0:0.00}/{1:0.00}" FallbackValue="xxx/xxx">
-                            <Binding Path="BuddyTotalKM"></Binding>
-                            <Binding Path="BuddyCurrentKM"></Binding>
-                        </MultiBinding>
-                    </TextBlock.Text>
-                </TextBlock>
+            <Image Name="image" Width="45" Source="{Binding Path=BuddyPokemonId, FallbackValue=https://raw.githubusercontent.com/Necrobot-Private/PokemonGO-Assets/master/pokemon/0.png, Converter={StaticResource PokemonIdToImageConverter}}"/>
+            <TextBlock TextAlignment="Center" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Light">
+                <TextBlock.Text>
+                    <MultiBinding  StringFormat="{}{0:0.00}/{1:0.00}" FallbackValue="xxx/xxx">
+                        <Binding Path="BuddyTotalKM"></Binding>
+                        <Binding Path="BuddyCurrentKM"></Binding>
+                    </MultiBinding>
+                </TextBlock.Text>
+            </TextBlock>
         </StackPanel>
-        
         <Grid Margin="10,0,0,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="3*"></ColumnDefinition>
@@ -40,16 +36,14 @@
                 <RowDefinition Height="25"></RowDefinition>
                 <RowDefinition Height="25"></RowDefinition>
             </Grid.RowDefinitions>
-
-            <TextBlock Grid.Column="0" Grid.Row="0">
+            <TextBlock Grid.Column="0" Grid.Row="0" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Light">
                 <TextBlock.Text>
                     <MultiBinding StringFormat="Level: {0}" FallbackValue="Level: 40">
                         <Binding Path="Level" />
                     </MultiBinding>
                 </TextBlock.Text>
             </TextBlock>
-
-            <TextBlock  Grid.Column="1" Grid.Row="0">
+            <TextBlock Grid.Column="1" Grid.Row="0" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Light">
                 <TextBlock.Text>
                     <MultiBinding StringFormat="EXP: {0}/{1} ({2}%)" FallbackValue="EXP: 100000/500000 (20%)">
                         <Binding Path="Exp" />
@@ -58,14 +52,12 @@
                     </MultiBinding>
                 </TextBlock.Text>
             </TextBlock>
-            <TextBlock Grid.Column="2" Grid.Row="0" x:Name="textBlock" HorizontalAlignment="Left"  TextWrapping="Wrap" Text="{Binding Path=EXPPerHour, FallbackValue=EXP/H: 123, StringFormat=EXP/H: {0}, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Top"/>
-            <TextBlock Grid.Column="3" Grid.Row="0" x:Name="textBlock_Copy" HorizontalAlignment="Left" TextWrapping="Wrap" Text="{Binding Path=PKMPerHour, FallbackValue=PKM/H: 123 ,StringFormat=PKM/H: {0}, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Top" RenderTransformOrigin="6.212,4.375"/>
-            <TextBlock Grid.Column="0" Grid.Row="1" x:Name="textBlock1" HorizontalAlignment="Left"  TextWrapping="Wrap" Text="{Binding Runtime, FallbackValue=Runtime: xx:xx:xx:xx, StringFormat=Runtime: {0}, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Top"/>
-
-            <TextBlock Grid.Column="1" Grid.Row="1" x:Name="textBlock2" HorizontalAlignment="Left" TextWrapping="Wrap" Text="{Binding TimeToLevelUp, FallbackValue=Level Up in :1d 24h, StringFormat=Level Up in {0}, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Top" RenderTransformOrigin="-0.51,0.5"/>
-            <TextBlock Grid.Column="2" Grid.Row="1" x:Name="textBlock3" HorizontalAlignment="Left" TextWrapping="Wrap" Text="{Binding Stardust, FallbackValue=Stardust: 90000, StringFormat=Stardust: \{0\}, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Top"/>
-
-            <TextBlock Grid.Column="4" Grid.Row="1"  HorizontalAlignment="Left" TextWrapping="Wrap" VerticalAlignment="Top">
+            <TextBlock Grid.Column="2" Grid.Row="0" x:Name="textBlock" HorizontalAlignment="Left" TextWrapping="Wrap" Text="{Binding Path=EXPPerHour, FallbackValue=EXP/H: 123, StringFormat=EXP/H: {0}, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Top" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Light"/>
+            <TextBlock Grid.Column="3" Grid.Row="0" x:Name="textBlock_Copy" HorizontalAlignment="Left" TextWrapping="Wrap" Text="{Binding Path=PKMPerHour, FallbackValue=PKM/H: 123 ,StringFormat=PKM/H: {0}, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Top" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Light"/>
+            <TextBlock Grid.Column="0" Grid.Row="1" x:Name="textBlock1" HorizontalAlignment="Left" TextWrapping="Wrap" Text="{Binding Runtime, FallbackValue=Runtime: xx:xx:xx:xx, StringFormat=Runtime: {0}, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Top" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Light"/>
+            <TextBlock Grid.Column="1" Grid.Row="1" x:Name="textBlock2" HorizontalAlignment="Left" TextWrapping="Wrap" Text="{Binding TimeToLevelUp, FallbackValue=Level Up in :1d 24h, StringFormat=Level Up in {0}, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Top" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Light"/>
+            <TextBlock Grid.Column="2" Grid.Row="1" x:Name="textBlock3" HorizontalAlignment="Left" TextWrapping="Wrap" Text="{Binding Stardust, FallbackValue=Stardust: 90000, StringFormat=Stardust: \{0\}, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Top" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Light"/>
+            <TextBlock Grid.Column="4" Grid.Row="1"  HorizontalAlignment="Left" TextWrapping="Wrap" VerticalAlignment="Top" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Light">
                 <TextBlock.Text>
                     <MultiBinding Converter="{StaticResource ResourceKey=I18NMultiConveter}">
                         <Binding Source="PokestopLimit"></Binding>
@@ -73,8 +65,7 @@
                     </MultiBinding>
                 </TextBlock.Text>
             </TextBlock>
-
-            <TextBlock Grid.Column="4" Grid.Row="0"  HorizontalAlignment="Left" TextWrapping="Wrap" VerticalAlignment="Top">
+            <TextBlock Grid.Column="4" Grid.Row="0"  HorizontalAlignment="Left" TextWrapping="Wrap" VerticalAlignment="Top" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Light">
                 <TextBlock.Text>
                     <MultiBinding Converter="{StaticResource ResourceKey=I18NMultiConveter}">
                         <Binding Source="CatchLimit"></Binding>
@@ -82,8 +73,7 @@
                     </MultiBinding>
                 </TextBlock.Text>
             </TextBlock>
-
-            <TextBlock Grid.Column="3" Grid.Row="1"  HorizontalAlignment="Left" TextWrapping="Wrap" VerticalAlignment="Top">
+            <TextBlock Grid.Column="3" Grid.Row="1"  HorizontalAlignment="Left" TextWrapping="Wrap" VerticalAlignment="Top" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Light">
                 <TextBlock.Text>
                     <MultiBinding Converter="{StaticResource ResourceKey=I18NMultiConveter}">
                         <Binding Source="WalkSpeed"></Binding>
@@ -91,8 +81,7 @@
                     </MultiBinding>
                 </TextBlock.Text>
             </TextBlock>
-
-            <TextBlock Grid.Column="0" Grid.Row="2"  HorizontalAlignment="Left" TextWrapping="Wrap" VerticalAlignment="Top">
+            <TextBlock Grid.Column="0" Grid.Row="2"  HorizontalAlignment="Left" TextWrapping="Wrap" VerticalAlignment="Top" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Light">
                 <TextBlock.Text>
                     <MultiBinding Converter="{StaticResource ResourceKey=I18NMultiConveter}">
                         <Binding Source="PokemonTransfered"></Binding>
@@ -100,9 +89,6 @@
                     </MultiBinding>
                 </TextBlock.Text>
             </TextBlock>
-            
-
         </Grid>
     </DockPanel>
-
 </UserControl>

--- a/PoGo.Necrobot.Window/Controls/PokemonInventory.xaml
+++ b/PoGo.Necrobot.Window/Controls/PokemonInventory.xaml
@@ -33,9 +33,9 @@
 
             </Button>
             <StackPanel Orientation="Horizontal">
-
                 <Button x:Name="btnTransferAll" Margin="0,0,10,0" Content="Transfer All" Click="BtnTransferAll_Click"/>
-                <Button x:Name="btnFavoriteAll" Margin="0,0,10,0" Content="Favorite All"/>
+                <Button x:Name="btnEvolveAll" Margin="0,0,10,0" Content="Evolve All" IsEnabled="False"/>
+                <Button x:Name="btnFavoriteAll" Margin="0,0,10,0" Content="Favorite All" IsEnabled="False"/>
                 <Button x:Name="btnPokedexView" Click="BtnPokedexView_Click">
                     <StackPanel Orientation="Horizontal" >
                         <Image Source="http://allaboutwindowsphone.com/images/appicons/208046.png" Width="20px"></Image>

--- a/PoGo.Necrobot.Window/Controls/SnipeGrid.xaml
+++ b/PoGo.Necrobot.Window/Controls/SnipeGrid.xaml
@@ -40,7 +40,7 @@
                             </Storyboard>
                         </ControlTemplate.Resources>
                         <my:DataGridHeaderBorder x:Name="dataGridHeaderBorder" Margin="0" VerticalAlignment="Top" Height="31" IsClickable="{TemplateBinding CanUserSort}" IsHovered="{TemplateBinding IsMouseOver}" IsPressed="{TemplateBinding IsPressed}" SeparatorBrush="{TemplateBinding SeparatorBrush}" SeparatorVisibility="{TemplateBinding SeparatorVisibility}" SortDirection="{TemplateBinding SortDirection}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Padding="{TemplateBinding Padding}" Grid.ColumnSpan="1">
-                            <Grid x:Name="grid" Width="Auto" Height="Auto" RenderTransformOrigin="0.5,0.5">
+                            <Grid x:Name="grid" Width="Auto" Height="Auto">
                                 <Grid.RenderTransform>
                                     <TransformGroup>
                                         <ScaleTransform/>
@@ -91,7 +91,8 @@
               AutoGenerateColumns="false" 
               GridLinesVisibility="None"
               IsReadOnly="True"
-              behaviors:DataGridBehavior.DisplayRowNumber="True">
+              behaviors:DataGridBehavior.DisplayRowNumber="True"
+              FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium">
         <DataGrid.Columns>
             <DataGridTextColumn Binding="{Binding Path=Id}" Header="#" IsReadOnly="True"/>
             <DataGridTemplateColumn Header="#">

--- a/PoGo.Necrobot.Window/Controls/SniperControl.xaml
+++ b/PoGo.Necrobot.Window/Controls/SniperControl.xaml
@@ -28,85 +28,75 @@
                 <Setter Property="Padding" Value="3" />
             </Style>
         </TabControl.Resources>
-            
         <TabItem>
             <TabItem.Header>
-                <TextBlock Margin="5,2,5,2" Text="{Binding Source=TabSnipeRarePokemon, Converter={StaticResource I18NConveter}}"></TextBlock>
+                <TextBlock Margin="5,2,5,2" Text="{Binding Source=TabSnipeRarePokemon, Converter={StaticResource I18NConveter}}" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium"/>
             </TabItem.Header>
             <local:SnipeGrid DataContext="{Binding Path=RareList}" OnSnipePokemon="SnipeGrid_OnSnipePokemon"/>
         </TabItem>
-            
-        <TabItem >
+        <TabItem>
             <TabItem.Header>
-                <TextBlock Margin="5,2,5,2" Text="{Binding Source=TabSnipeIV100, Converter={StaticResource I18NConveter}}"></TextBlock>
+                <TextBlock Margin="5,2,5,2" Text="{Binding Source=TabSnipeIV100, Converter={StaticResource I18NConveter}}" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium"/>
             </TabItem.Header>
-            
             <local:SnipeGrid DataContext="{Binding Path=IV100List}" OnSnipePokemon="SnipeGrid_OnSnipePokemon" />
         </TabItem>
-        <TabItem >
+        <TabItem>
             <TabItem.Header>
-                <TextBlock Margin="5,2,5,2" Text="{Binding Source=TabSnipeOtherPokemon, Converter={StaticResource I18NConveter}}"></TextBlock>
+                <TextBlock Margin="5,2,5,2" Text="{Binding Source=TabSnipeOtherPokemon, Converter={StaticResource I18NConveter}}" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium"/>
             </TabItem.Header>
             <local:SnipeGrid DataContext="{Binding Path=OtherList}" OnSnipePokemon="SnipeGrid_OnSnipePokemon"/>
         </TabItem>
-        <TabItem >
+        <TabItem>
             <TabItem.Header>
-                <TextBlock Margin="5,2,5,2" Text="{Binding Source=TabSnipeAutoListPokemon, Converter={StaticResource I18NConveter}}"></TextBlock>
+                <TextBlock Margin="5,2,5,2" Text="{Binding Source=TabSnipeAutoListPokemon, Converter={StaticResource I18NConveter}}" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium"/>
             </TabItem.Header>
             <local:SnipeGrid DataContext="{Binding Path=SnipeQueueItems}"/>
-            
         </TabItem>
-        
         <TabItem>
             <TabItem.Header>
-                <TextBlock Margin="5,2,5,2" Text="{Binding Source=TabSnipeNotInDexPokemon, Converter={StaticResource I18NConveter}}"></TextBlock>
+                <TextBlock Margin="5,2,5,2" Text="{Binding Source=TabSnipeNotInDexPokemon, Converter={StaticResource I18NConveter}}" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium"/>
             </TabItem.Header>
-            
             <local:SnipeGrid DataContext="{Binding Path=PokedexSnipeItems}" OnSnipePokemon="SnipeGrid_OnSnipePokemon"/>
         </TabItem>
-
         <TabItem>
             <TabItem.Header>
-                <TextBlock Margin="5,2,5,2" Text="{Binding Source=TabSnipeAddManualCoord, Converter={StaticResource I18NConveter}}"></TextBlock>
+                <TextBlock Margin="5,2,5,2" Text="{Binding Source=TabSnipeAddManualCoord, Converter={StaticResource I18NConveter}}" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium"/>
             </TabItem.Header>
-            
             <Grid Margin="50,50,50,50">
                 <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="100" />
-                <ColumnDefinition Width="5*" />
-                <ColumnDefinition Width="2*" />
+                    <ColumnDefinition Width="100" />
+                    <ColumnDefinition Width="5*" />
+                    <ColumnDefinition Width="2*" />
                 </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="30"  />
-                    <RowDefinition Height="10"  />
                     <RowDefinition Height="30" />
-                    <RowDefinition Height="10"  />
+                    <RowDefinition Height="10" />
                     <RowDefinition Height="30" />
-                    <RowDefinition Height="10"  />
+                    <RowDefinition Height="10" />
+                    <RowDefinition Height="30" />
+                    <RowDefinition Height="10" />
                     <RowDefinition Height="150" />
                     <RowDefinition Height="10"  />
                     <RowDefinition Height="30" />
                 </Grid.RowDefinitions>
-                <TextBlock Text="{Binding Source=Latitude, Converter={StaticResource I18NConveter}}" Grid.Column="0" Grid.Row="0"></TextBlock>
-                <TextBlock Text="{Binding Source=Longitude, Converter={StaticResource I18NConveter}}" Grid.Column="0" Grid.Row="2" ></TextBlock>
-                <TextBlock Text="{Binding Source=PokemonName, Converter={StaticResource I18NConveter}}" Grid.Column="0" Grid.Row="4"></TextBlock>
-                <TextBlock Text="{Binding Source=FreeInput, Converter={StaticResource I18NConveter}}" Grid.Column="0" Grid.Row="6"></TextBlock>
-
-                <TextBox Text="{Binding Path=ManualSnipe.Latitude, Mode=TwoWay}" Grid.Column="1" Grid.Row="0" HorizontalAlignment="Stretch"></TextBox>
-                <TextBox Text="{Binding Path=ManualSnipe.Longitude , Mode=TwoWay}" Grid.Column="1" Grid.Row="2" HorizontalAlignment="Stretch"></TextBox>
-                <ComboBox  Grid.Column="1" Grid.Row="4" Name="cobPokemonId"  SelectedValue="{Binding Path=ManualSnipe.PokemonId, Mode=TwoWay}" ></ComboBox>
+                <TextBlock Text="{Binding Source=Latitude, Converter={StaticResource I18NConveter}}" Grid.Column="0" Grid.Row="0" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium"/>
+                <TextBlock Text="{Binding Source=Longitude, Converter={StaticResource I18NConveter}}" Grid.Column="0" Grid.Row="2" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium"/>
+                <TextBlock Text="{Binding Source=PokemonName, Converter={StaticResource I18NConveter}}" Grid.Column="0" Grid.Row="4" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium"/>
+                <TextBlock Text="{Binding Source=FreeInput, Converter={StaticResource I18NConveter}}" Grid.Column="0" Grid.Row="6" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium"/>
+                <TextBox Text="{Binding Path=ManualSnipe.Latitude, Mode=TwoWay}" Grid.Column="1" Grid.Row="0" HorizontalAlignment="Stretch" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium"/>
+                <TextBox Text="{Binding Path=ManualSnipe.Longitude , Mode=TwoWay}" Grid.Column="1" Grid.Row="2" HorizontalAlignment="Stretch" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium"/>
+                <ComboBox  Grid.Column="1" Grid.Row="4" Name="cobPokemonId"  SelectedValue="{Binding Path=ManualSnipe.PokemonId, Mode=TwoWay}" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium"/>
                 <DockPanel LastChildFill="True" Grid.Column="1" Grid.Row="6">
-                    <TextBlock DockPanel.Dock="Top" Text="{Binding Source=FreeInputExplain, Converter={StaticResource I18NConveter}}"></TextBlock>
-                    <RichTextBox  TextChanged="RichTextBox_TextChanged" Name="rtbFreeText" >
+                    <TextBlock DockPanel.Dock="Top" Text="{Binding Source=FreeInputExplain, Converter={StaticResource I18NConveter}}" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium"/>
+                    <RichTextBox TextChanged="RichTextBox_TextChanged" Name="rtbFreeText" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium">
                         <FlowDocument>
                             <Paragraph>
-                                <Run Text="{Binding Path=ManualSnipe.InputText, Mode=TwoWay}" />
+                                <Run Text="{Binding Path=ManualSnipe.InputText, Mode=TwoWay}" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium"/>
                             </Paragraph>
                         </FlowDocument>
                     </RichTextBox>
-               </DockPanel>
-
-                <Button Grid.Column="1" Grid.Row="8" Content="{Binding Source=AddToSnipeButtonText, Converter={StaticResource I18NConveter}}" Name="btnAddCoord" Click="BtnAddCoord_Click" ></Button>
+                </DockPanel>
+                <Button Grid.Column="1" Grid.Row="8" Content="{Binding Source=AddToSnipeButtonText, Converter={StaticResource I18NConveter}}" Name="btnAddCoord" Click="BtnAddCoord_Click" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium"/>
             </Grid>
         </TabItem>
     </TabControl>

--- a/PoGo.Necrobot.Window/MainClientWindow.xaml
+++ b/PoGo.Necrobot.Window/MainClientWindow.xaml
@@ -6,10 +6,11 @@
                       xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
                       xmlns:local="clr-namespace:PoGo.Necrobot.Window.Controls"
                       xmlns:c="clr-namespace:PoGo.Necrobot.Window.Converters"
-                      Title="Necrobot 2 - Window GUI"
+                      Title="Necrobot 2 - Windows GUI"
                       Height="768"
                       Width="1366"
                       MinWidth="1024"
+                      MinHeight="576"
                       BorderThickness="0"
                       GlowBrush="DodgerBlue"
                       ResizeMode="CanResizeWithGrip"
@@ -19,12 +20,12 @@
     <Controls:MetroWindow.TitleTemplate>
         <DataTemplate>
             <TextBlock x:Name="TitleText"
-                       Text="Necrobot 2 - Window GUI"
+                       Text="Necrobot 2 - Windows GUI"
                        TextTrimming="CharacterEllipsis"
                        VerticalAlignment="Center"
                        Margin="4, 0, 0, 0"
-                       FontWeight="Normal"
-                       FontFamily="pack://application:,,,/Resources/#Lato-light"/>
+                       FontWeight="Medium"
+                       FontFamily="pack://application:,,,/Resources/Fonts/#Lato"/>
         </DataTemplate>
     </Controls:MetroWindow.TitleTemplate>
     <Control.Resources>
@@ -33,7 +34,7 @@
         <c:TimestampToDateTimeConverter x:Key="TimestampToDateTimeConverter"/>
         <c:DurationTextConverter x:Key="DurationTextConverter"/>
         <Style x:Key="LatoFont">
-            <Setter Property="TextElement.FontFamily" Value="pack://application:,,,/Resources/#Lato-light" />
+            <Setter Property="TextElement.FontFamily" Value="pack://application:,,,/Resources/Fonts/#Lato" />
         </Style>
     </Control.Resources>
     <Controls:MetroWindow.RightWindowCommands>
@@ -45,14 +46,14 @@
                             <VisualBrush Stretch="Fill" Visual="{DynamicResource appbar_book_perspective_help}" />
                         </Rectangle.OpacityMask>
                     </Rectangle>
-                    <TextBlock Margin="4 0 0 0" VerticalAlignment="Center" Text="{Binding Source=Help, Converter={StaticResource ResourceKey=I18NConveter}}" />
+                    <TextBlock Margin="4 0 0 0" VerticalAlignment="Center" Text="{Binding Source=Help, Converter={StaticResource ResourceKey=I18NConveter}}" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium" />
                     <Popup Margin="10,10,10,10" Name="popHelpArticles" HorizontalAlignment="Left" VerticalAlignment="Top" StaysOpen="False" Width="420" Height="580" IsOpen="False" AllowsTransparency="True">
                         <Grid Background="WhiteSmoke">
                             <ListView Name="lsvHelps" Margin="20">
                                 <ListView.ItemTemplate>
                                     <DataTemplate>
                                         <StackPanel Orientation="Horizontal">
-                                            <TextBlock FontFamily="/NecroBot2.Win;component/Resources/Fonts/Lato/#Lato Medium">
+                                            <TextBlock FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium">
                                                 <Hyperlink NavigateUri="{Binding Id}" Click="Hyperlink_Click" CommandParameter="{Binding}">
                                                     <TextBlock Text="{Binding Path=Title.Text}"></TextBlock>
                                                 </Hyperlink>
@@ -65,17 +66,17 @@
                     </Popup>
                 </StackPanel>
             </Button>
-            <ComboBox x:Name="Theme" IsEditable="True" IsReadOnly="True" SelectionChanged="Theme_SelectionChanged" Background="{x:Null}" BorderBrush="{x:Null}" Width="120" ToolTip="Set Theme" />
-            <ComboBox x:Name="Scheme" IsEditable="True" IsReadOnly="True" SelectionChanged="Scheme_SelectionChanged" Background="{x:Null}" BorderBrush="{x:Null}" Width="120" ToolTip="Set Scheme" />
-            <ComboBox x:Name="MapMode" IsEditable="True" IsReadOnly="True" SelectionChanged="MapMode_SelectionChanged" Background="{x:Null}" BorderBrush="{x:Null}" Width="120" ToolTip="Set Map Mode" />
+            <ComboBox x:Name="Theme" IsEditable="True" IsReadOnly="True" SelectionChanged="Theme_SelectionChanged" Background="{x:Null}" Foreground="#FFF1F1F1" BorderBrush="{x:Null}" Width="120" ToolTip="Set Theme" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium" VerticalContentAlignment="Center" />
+            <ComboBox x:Name="Scheme" IsEditable="True" IsReadOnly="True" SelectionChanged="Scheme_SelectionChanged" Background="{x:Null}" Foreground="#FFF1F1F1" BorderBrush="{x:Null}" Width="120" ToolTip="Set Scheme" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium" VerticalContentAlignment="Center" />
+            <ComboBox x:Name="MapMode" IsEditable="True" IsReadOnly="True" SelectionChanged="MapMode_SelectionChanged" Background="{x:Null}" Foreground="#FFF1F1F1" BorderBrush="{x:Null}" Width="120" ToolTip="Set Map Mode" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium" VerticalContentAlignment="Center" />
             <Button x:Name="DefaultReset" Click="DefaultReset_Click">
                 <StackPanel Orientation="Horizontal">
-                    <TextBlock Margin="4 0 0 0" x:Name="defaultResetText" VerticalAlignment="Center" Text="{Binding Source=ResetLayout, Converter={StaticResource ResourceKey=I18NConveter}}" />
+                    <TextBlock Margin="4 0 0 0" x:Name="defaultResetText" VerticalAlignment="Center" Text="{Binding Source=ResetLayout, Converter={StaticResource ResourceKey=I18NConveter}}" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium" />
                 </StackPanel>
             </Button>
             <Button x:Name="BrowserToggle" Click="BrowserToggle_Click">
                 <StackPanel Orientation="Horizontal">
-                    <TextBlock Margin="4 0 0 0" x:Name="browserMenuText" VerticalAlignment="Center" Text="{Binding Source=DisableHub, Converter={StaticResource ResourceKey=I18NConveter}}" />
+                    <TextBlock Margin="4 0 0 0" x:Name="browserMenuText" VerticalAlignment="Center" Text="{Binding Source=DisableHub, Converter={StaticResource ResourceKey=I18NConveter}}" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium" />
                 </StackPanel>
             </Button>
             <Button x:Name="menuConsole" Click="MenuConsole_Click">
@@ -85,7 +86,7 @@
                             <VisualBrush Stretch="Fill" Visual="{DynamicResource appbar_console}" />
                         </Rectangle.OpacityMask>
                     </Rectangle>
-                    <TextBlock Margin="4 0 0 0" Name="consoleMenuText" VerticalAlignment="Center" Text="{Binding Source=ShowConsole, Converter={StaticResource ResourceKey=I18NConveter}}" />
+                    <TextBlock Margin="4 0 0 0" Name="consoleMenuText" VerticalAlignment="Center" Text="{Binding Source=ShowConsole, Converter={StaticResource ResourceKey=I18NConveter}}" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium" />
                 </StackPanel>
             </Button>
             <Button Click="MenuSetting_Click" Name="menuSetting">
@@ -95,7 +96,7 @@
                             <VisualBrush Stretch="Fill" Visual="{DynamicResource appbar_settings}" />
                         </Rectangle.OpacityMask>
                     </Rectangle>
-                    <TextBlock Margin="4 0 0 0" VerticalAlignment="Center" Text="{Binding Source=MenuSetting, Converter={StaticResource I18NConveter}}" />
+                    <TextBlock Margin="4 0 0 0" VerticalAlignment="Center" Text="{Binding Source=MenuSetting, Converter={StaticResource I18NConveter}}" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium" />
                 </StackPanel>
             </Button>
             <Button Name="btnDonate" Click="BtnDonate_Click" Margin="0,0,0,0">
@@ -106,41 +107,21 @@
         </Controls:WindowCommands>
     </Controls:MetroWindow.RightWindowCommands>
     <DockPanel LastChildFill="True">
-        <Popup Name="popSwithAccount" Placement="Center" IsOpen="False" Width="300" Height="90" >
-            <Border BorderBrush="Coral" Background="Black" BorderThickness="4">
-                <StackPanel Margin="30,30,30,30">
-                    <TextBlock Name="txtMessage" Text="{Binding Source=AccountSwitching, Converter={StaticResource ResourceKey=I18NConveter}}" Foreground="Red" FontStretch="UltraExpanded" FontStyle="Italic" FontWeight="UltraBold" TextAlignment="Center" TextWrapping="Wrap" FontSize="16" FontFamily="Century Gothic"></TextBlock>
-                </StackPanel>
-            </Border>
-        </Popup>
-        <Popup Name="popError" Placement="Center" IsOpen="False" Width="400" Height="auto" >
-            <Border BorderBrush="Red" Background="WhiteSmoke" BorderThickness="2">
-                <StackPanel>
-                    <StackPanel Background="Red">
-                        <TextBlock Text="{Binding Source=ErrorPopupTitle, Converter={StaticResource I18NConveter}}" Margin="5,5,5,5" FontSize="18.667" FontFamily="/NecroBot2.Win;component/Resources/Fonts/Lato/#Lato Heavy" Foreground="White"></TextBlock>
-                    </StackPanel>
-                    <StackPanel Margin="10">
-                        <TextBlock Name="txtLastError" Text="" TextWrapping="Wrap" FontFamily="/NecroBot2.Win;component/Resources/Fonts/Lato/#Lato" FontSize="16"></TextBlock>
-                        <Button Margin="10,10,10,10" Click="BtnExit_Click" Name="btnExit" Content="{Binding Source=ClickHereExit, Converter={StaticResource I18NConveter}}" FontFamily="/NecroBot2.Win;component/Resources/Fonts/Lato/#Lato Heavy" FontSize="18.667" ></Button>
-                    </StackPanel>
-                </StackPanel>
-            </Border>
-        </Popup>
         <GroupBox x:Name="grbPlayerInfo" DockPanel.Dock="Top" Height="120" Margin="2">
             <GroupBox.Header>
                 <DockPanel LastChildFill="True">
                     <Button Content="Hide" DockPanel.Dock="Right" Name="btnHideInfo" Click="BtnHideInfo_Click" />
-                    <Label Content="Logging in ..... check console window for details" Name="lblAccount" Foreground="White" FontWeight="Bold" />
+                    <Label Content="Logging in (Check Console Tab/Window for Details)" Name="lblAccount" Foreground="White" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Bold" />
                 </DockPanel>
             </GroupBox.Header>
             <local:PlayerInfo DataContext="{Binding Path=PlayerInfo}" />
         </GroupBox>
         <StatusBar DockPanel.Dock="Bottom">
             <StatusBarItem>
-                <TextBlock Name="lblStatus" />
+                <TextBlock Name="lblStatus" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium" />
             </StatusBarItem>
             <StatusBarItem>
-                <TextBlock Name="lblCount" />
+                <TextBlock Name="lblCount" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium" />
             </StatusBarItem>
         </StatusBar>
         <TabControl TabStripPlacement="Bottom" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" VerticalAlignment="Stretch" Name="tabMain" SelectionChanged="TabMain_SelectionChanged" Margin="0,0,0,0">
@@ -149,22 +130,22 @@
                     <Setter Property="HorizontalAlignment" Value="Center" />
                 </Style>
             </TabControl.Resources>
-            <TabItem Name="tabAccounts" Width="80" Height="70" Cursor="Hand">
+            <TabItem Name="tabAccounts" Width="80" Height="70" Cursor="Hand" Background="{x:Null}">
                 <TabItem.Header>
                     <Image x:Name="accountsIMG" Source="Resources/Accounts/AccountsImage.png" Width="70" Height="65" />
                 </TabItem.Header>
-                <DataGrid Name="gridAccounts" AutoGenerateColumns="False" CanUserDeleteRows="False" CanUserAddRows="False">
+                <DataGrid Name="gridAccounts" AutoGenerateColumns="False" CanUserDeleteRows="False" CanUserAddRows="False" FontFamily="pack://application:,,,/Resources/Fonts/#Lato">
                     <DataGrid.Columns>
-                        <DataGridTextColumn Binding="{Binding AuthType}" Header="AuthType"></DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding Username}" Header="Username"></DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding Password}" Header="Password"></DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding Nickname}" Header="Nickname"></DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding Level}" Header="Level"></DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding ExperienceInfo}" Header="Experience"></DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding Stardust}" Header="Stardust"></DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding LastLogin}" Header="Login Status"></DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding LastLoginTimestamp, Converter={StaticResource TimestampToDateTimeConverter }}" Header="Login Time"></DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding RuntimeTotal, Converter={StaticResource DurationTextConverter} }" Header="Runtime"></DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding AuthType}" Header="AuthType" FontWeight="Medium"></DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding Username}" Header="Username" FontWeight="Medium"></DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding Password}" Header="Password" FontWeight="Medium"></DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding Nickname}" Header="Nickname" FontWeight="Medium"></DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding Level}" Header="Level" FontWeight="Medium"></DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding ExperienceInfo}" Header="Experience" FontWeight="Medium"></DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding Stardust}" Header="Stardust" FontWeight="Medium"></DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding LastLogin}" Header="Login Status" FontWeight="Medium"></DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding LastLoginTimestamp, Converter={StaticResource TimestampToDateTimeConverter}}" Header="Login Time" FontWeight="Medium"></DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding RuntimeTotal, Converter={StaticResource DurationTextConverter}}" Header="Runtime" FontWeight="Medium"></DataGridTextColumn>
                         <DataGridTemplateColumn Header="">
                             <DataGridTemplateColumn.CellEditingTemplate>
                                 <DataTemplate />
@@ -173,7 +154,7 @@
                                 <DataTemplate>
                                     <StackPanel>
                                         <Button Name="btnSwitchAcount" Click="BtnSwitchAcount_Click" CommandParameter="{Binding}" Foreground="Green" Background="Transparent"  IsEnabled="{Binding IsRunning, Converter= {StaticResource InverseBooleanConverter}}" Cursor="Hand">
-                                            <TextBlock Margin="5,5,5,5" Text="{Binding Source=Switch, Converter={StaticResource I18NConveter }}"></TextBlock>
+                                            <TextBlock Margin="5,5,5,5" Text="{Binding Source=Switch, Converter={StaticResource I18NConveter }}" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium"></TextBlock>
                                         </Button>
                                     </StackPanel>
                                 </DataTemplate>
@@ -182,13 +163,13 @@
                     </DataGrid.Columns>
                 </DataGrid>
             </TabItem>
-            <TabItem Name="tabBrowser" Width="80" Height="70" Cursor="Hand">
+            <TabItem Name="tabBrowser" Width="80" Height="70" Cursor="Hand" Background="{x:Null}">
                 <TabItem.Header>
                     <Image x:Name="browserIMG" Source="Resources/Hub/HubImage.png" Width="70" Height="65" />
                 </TabItem.Header>
                 <Grid Name="browserLayout" />
             </TabItem>
-            <TabItem Name="tabMap" Width="80" Height="70" Cursor="Hand">
+            <TabItem Name="tabMap" Width="80" Height="70" Cursor="Hand" Background="{x:Null}">
                 <TabItem.Header>
                     <Image x:Name="mapIMG" Source="Resources/Map/MapImage.png" Width="70" Height="65" />
                 </TabItem.Header>
@@ -198,18 +179,18 @@
                         <ColumnDefinition Width="5" />
                         <ColumnDefinition Width="auto" />
                     </Grid.ColumnDefinitions>
-                    <local:MapControl x:Name="botMap" Grid.Column="0" DataContext="{Binding Path=Map}" />
+                    <local:MapControl x:Name="botMap" Grid.Column="0" DataContext="{Binding Path=Map}" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium" />
                     <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch" />
-                    <local:SidebarControl Visibility="Visible" DataContext="{Binding Path=Sidebar}" x:Name="sidebarControl" Grid.Column="2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" MinWidth="200" />
+                    <local:SidebarControl Visibility="Visible" DataContext="{Binding Path=Sidebar}" x:Name="sidebarControl" Grid.Column="2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" MinWidth="200" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium" />
                 </Grid>
             </TabItem>
-            <TabItem x:Name="tabSniper" Width="80" Height="70" Cursor="Hand">
+            <TabItem x:Name="tabSniper" Width="80" Height="70" Cursor="Hand" Background="{x:Null}">
                 <TabItem.Header>
                     <Image x:Name="sniperIMG" Source="Resources/Sniper/SniperImage.png" Width="70" Height="65" />
                 </TabItem.Header>
-                <local:SniperControl x:Name="ctrlSniper" DataContext="{Binding Path=SnipeList}" />
+                <local:SniperControl x:Name="ctrlSniper" DataContext="{Binding Path=SnipeList}" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" />
             </TabItem>
-            <TabItem x:Name="tabConsole" IsSelected="True" Width="80" Height="70" Cursor="Hand">
+            <TabItem x:Name="tabConsole" IsSelected="True" Width="80" Height="70" Cursor="Hand" Background="{x:Null}">
                 <TabItem.Header>
                     <Image x:Name="consoleIMG" Source="Resources/Console/ConsoleImage.png" Width="65" Height="65" />
                 </TabItem.Header>
@@ -220,11 +201,11 @@
                     <ColumnDefinition Width="1" />
                     <ColumnDefinition Width="150" />
                   </Grid.ColumnDefinitions>
-                  <TextBox x:Name="txtCmdInput" Grid.Column="0" ToolTip="{Binding Source=InputCommand, Converter={StaticResource ResourceKey=I18NConveter}}" MouseDown="TxtCmdInput_MouseDown" KeyDown="TxtCmdInput_KeyDown" />
+                        <TextBox x:Name="txtCmdInput" Grid.Column="0" ToolTip="{Binding Source=InputCommand, Converter={StaticResource ResourceKey=I18NConveter}}" MouseDown="TxtCmdInput_MouseDown" KeyDown="TxtCmdInput_KeyDown" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium" />
                   <GridSplitter Grid.Column="1" />
-                  <ComboBox x:Name="ConsoleThemer" Grid.Column="2" IsEditable="False" IsReadOnly="True" SelectionChanged="ConsoleThemer_SelectionChanged" BorderBrush="#FFCCCCCC" ToolTip="Set Console Colors" />
+                        <ComboBox x:Name="ConsoleThemer" Grid.Column="2" IsEditable="False" IsReadOnly="True" SelectionChanged="ConsoleThemer_SelectionChanged" BorderBrush="#FFCCCCCC" ToolTip="Set Console Colors" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium" />
                 </Grid>
-                <RichTextBox ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.CanContentScroll="True" DockPanel.Dock="Bottom" x:Name="consoleLog" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontSize="15" IsReadOnly="True" FontFamily="/NecroBot2.Win;component/Resources/Fonts/Lato/#Lato Light">
+                <RichTextBox ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.CanContentScroll="True" DockPanel.Dock="Bottom" x:Name="consoleLog" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontSize="15" IsReadOnly="True" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Light">
                   <FlowDocument>
                     <Paragraph LineHeight="25">
                       <Run Text="" />
@@ -233,32 +214,32 @@
                 </RichTextBox>
               </DockPanel>
             </TabItem>
-            <TabItem Name="tabPokemons" Width="80" Height="70" Cursor="Hand">
+            <TabItem Name="tabPokemons" Width="80" Height="70" Cursor="Hand" Background="{x:Null}">
                 <TabItem.Header>
                     <StackPanel Orientation="Vertical" RenderTransformOrigin="0.5,0.5" Width="80" HorizontalAlignment="Center" VerticalAlignment="Center">
                         <Image x:Name="pokemonIMG" Source="Resources/Pokemon/PokemonImage.png" Width="50" Height="50" />
-                        <TextBlock FontSize="12" HorizontalAlignment="Center" Text="{Binding Path= PokemonTabHeader, FallbackValue=Pokemon}"/>
+                        <TextBlock FontSize="12" HorizontalAlignment="Center" Text="{Binding Path= PokemonTabHeader, FallbackValue=Pokemon}" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium"/>
                     </StackPanel>
                 </TabItem.Header>
-                <local:PokemonInventory x:Name="ctrPokemonInventory" DataContext="{Binding Path=PokemonList}" OnPokemonItemSelected="PokemonInventory_OnPokemonItemSelected" />
+                <local:PokemonInventory x:Name="ctrPokemonInventory" DataContext="{Binding Path=PokemonList}" OnPokemonItemSelected="PokemonInventory_OnPokemonItemSelected" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" />
             </TabItem>
-            <TabItem Name="tabItems" Width="80" Height="70" Cursor="Hand">
+            <TabItem Name="tabItems" Width="80" Height="70" Cursor="Hand" Background="{x:Null}">
                 <TabItem.Header>
                     <StackPanel Orientation="Vertical" RenderTransformOrigin="0.5,0.5" Width="80" HorizontalAlignment="Center" VerticalAlignment="Center">
                         <Image x:Name="itemsIMG" Source="Resources/Items/ItemsImage.png" Width="50" Height="50" />
-                        <TextBlock FontSize="12" HorizontalAlignment="Center" Text="{Binding Path= ItemsTabHeader, FallbackValue=Items}"/>
+                        <TextBlock FontSize="12" HorizontalAlignment="Center" Text="{Binding Path= ItemsTabHeader, FallbackValue=Items}" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium"/>
                     </StackPanel>
                 </TabItem.Header>
-                <local:ItemsInventory DataContext="{Binding Path=ItemsList}" x:Name="ctrlItemControl" />
+                <local:ItemsInventory DataContext="{Binding Path=ItemsList}" x:Name="ctrlItemControl" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" />
             </TabItem>
-            <TabItem Name="tabEggs" Width="80" Height="70" Cursor="Hand">
+            <TabItem Name="tabEggs" Width="80" Height="70" Cursor="Hand" Background="{x:Null}">
                 <TabItem.Header>
                     <StackPanel Orientation="Vertical" RenderTransformOrigin="0.5,0.5" Width="80" HorizontalAlignment="Center" VerticalAlignment="Center">
                         <Image x:Name="eggsIMG" Source="Resources/Eggs/EggsImage.png" Width="50" Height="50" />
-                        <TextBlock FontSize="12" HorizontalAlignment="Center" Text="{Binding Path= EggsTabHeader, FallbackValue=Eggs}"/>
+                        <TextBlock FontSize="12" HorizontalAlignment="Center" Text="{Binding Path= EggsTabHeader, FallbackValue=Eggs}" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" FontWeight="Medium"/>
                     </StackPanel>
                 </TabItem.Header>
-                <local:EggsControl DataContext="{Binding Path=EggsList}" x:Name="ctrlEggsControl" />
+                <local:EggsControl DataContext="{Binding Path=EggsList}" x:Name="ctrlEggsControl" FontFamily="pack://application:,,,/Resources/Fonts/#Lato" />
             </TabItem>
         </TabControl>
     </DockPanel>

--- a/PoGo.Necrobot.Window/MainClientWindow.xaml.UIEvents.cs
+++ b/PoGo.Necrobot.Window/MainClientWindow.xaml.UIEvents.cs
@@ -5,12 +5,14 @@ using PoGo.NecroBot.Logic.Event.Inventory;
 using PoGo.NecroBot.Logic.Event.Player;
 using PoGo.NecroBot.Logic.Event.Snipe;
 using PoGo.NecroBot.Logic.Event.UI;
+using PoGo.NecroBot.Logic.Logging;
 using POGOProtos.Inventory.Item;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Windows;
 
 namespace PoGo.Necrobot.Window
 {
@@ -35,10 +37,11 @@ namespace PoGo.Necrobot.Window
         }
         public void OnBotEvent(BotSwitchedEvent ex)
         {
-            //this.botMap.Reset();
-            datacontext.Reset();
-            popSwithAccount.IsOpen = true;
-            //show popup...
+            Dispatcher.Invoke(() =>
+            {
+                datacontext.Reset();
+                lblAccount.Content = "Switching Account...";
+            });
         }
         public void OnBotEvent(FinishUpgradeEvent e)
         {
@@ -61,10 +64,8 @@ namespace PoGo.Necrobot.Window
             Dispatcher.Invoke(() =>
             {
                 datacontext.Reset();
-
                 lblAccount.Content = currentSession.Translation.GetTranslation(NecroBot.Logic.Common.TranslationString.LoggingIn, ev.AuthType, ev.Username);
             });
-
         }
         public void OnBotEvent(SnipePokemonStarted ex)
         {
@@ -122,9 +123,7 @@ namespace PoGo.Necrobot.Window
 
             Dispatcher.Invoke(() =>
             {
-                popSwithAccount.IsOpen = false;
                 lblAccount.Content = $"{datacontext.UI.PlayerStatus} as : {datacontext.UI.PlayerName}";
-
             });
         }
         public void OnBotEvent(ProfileEvent profile)
@@ -179,15 +178,19 @@ namespace PoGo.Necrobot.Window
         {
             datacontext.PlayerInfo.UpdateCatchLimit(ev);
         }
-
         public void OnBotEvent(ErrorEvent ev)
         {
-            if(ev.RequireExit)
+            Dispatcher.Invoke(() =>
             {
-                popSwithAccount.IsOpen = false;
-                txtLastError.Text = ev.Message;
-                popError.IsOpen = true;
-            }
+                if (ev.RequireExit)
+                {
+                    lblAccount.Content = "An Error has been Detected and the bot will Shut Down in 10 Seconds (Info in Console/Logs)";
+                    Logger.Write($"Error Detected! ({ev.Message})", LogLevel.Error);
+                    var ExitTime = DateTime.Now.AddSeconds(10);
+                    if (DateTime.Now > ExitTime)
+                        Application.Current.Shutdown();
+                }
+            });
         }
         public void OnBotEvent(IEvent evt)
         {

--- a/PoGo.Necrobot.Window/MainClientWindow.xaml.cs
+++ b/PoGo.Necrobot.Window/MainClientWindow.xaml.cs
@@ -45,33 +45,33 @@ namespace PoGo.Necrobot.Window
         private static Dictionary<LogLevel, Tuple<string, string, string>> ConsoleColors = new Dictionary<LogLevel, Tuple<string, string, string>>()
         {
             // Console Colors <Default, Solarized_Dark, Solarized_Light>
-                { LogLevel.Error, new Tuple<string, string, string>("Pink", "#FF1E8E", "") },
-                { LogLevel.Caught, new Tuple<string, string, string>("Green", "#83FF08", "") },
-                { LogLevel.Info, new Tuple<string, string, string>("Green", "#83FF08", "") },
-                { LogLevel.Warning, new Tuple<string, string, string>("Orange", "#FF8308", "") },
-                { LogLevel.Pokestop, new Tuple<string, string, string>("Cyan", "#B4E1FD", "") },
-                { LogLevel.Farming, new Tuple<string, string, string>("Green", "#83FF08", "") },
-                { LogLevel.Sniper, new Tuple<string, string, string>("Grey", "#B6B6B6", "") },
-                { LogLevel.Recycling, new Tuple<string, string, string>("Grey", "#B6B6B6", "") },
-                { LogLevel.Flee, new Tuple<string, string, string>("Purple", "#8308FF", "") },
-                { LogLevel.Transfer, new Tuple<string, string, string>("Grey", "#B6B6B6", "") },
-                { LogLevel.Evolve, new Tuple<string, string, string>("Cyan", "#B4E1FD", "") },
-                { LogLevel.Berry, new Tuple<string, string, string>("Orange", "#FF8308", "") },
-                { LogLevel.Egg, new Tuple<string, string, string>("Cyan", "#B4E1FD", "") },
-                { LogLevel.Debug, new Tuple<string, string, string>("Grey", "#B6B6B6", "") },
-                { LogLevel.Update, new Tuple<string, string, string>("Blue", "#0883FF", "") },
-                { LogLevel.New, new Tuple<string, string, string>("Blue", "#0883FF", "") },
-                { LogLevel.SoftBan, new Tuple<string, string, string>("Pink", "#FF1E8E", "") },
-                { LogLevel.LevelUp, new Tuple<string, string, string>("Blue", "#0883FF", "") },
-                { LogLevel.Gym, new Tuple<string, string, string>("Purple", "#8308FF", "") },
-                { LogLevel.Service , new Tuple<string, string, string>("Grey", "#B6B6B6", "") }
+                { LogLevel.Error, new Tuple<string, string, string>("Pink", "#FF1E8E", "#EC008C") },
+                { LogLevel.Caught, new Tuple<string, string, string>("Green", "#83FF08", "#03353E") },
+                { LogLevel.Info, new Tuple<string, string, string>("Orange", "#FF8308", "#FF6600") },
+                { LogLevel.Warning, new Tuple<string, string, string>("Orange", "#FF8308", "#FF6600") },
+                { LogLevel.Pokestop, new Tuple<string, string, string>("Cyan", "#B4E1FD", "#EC008C") },
+                { LogLevel.Farming, new Tuple<string, string, string>("Green", "#83FF08", "#03353E") },
+                { LogLevel.Sniper, new Tuple<string, string, string>("Grey", "#B6B6B6", "#03353E") },
+                { LogLevel.Recycling, new Tuple<string, string, string>("Grey", "#B6B6B6", "#03353E") },
+                { LogLevel.Flee, new Tuple<string, string, string>("Grey", "#B6B6B6", "#03353E") },
+                { LogLevel.Transfer, new Tuple<string, string, string>("Grey", "#B6B6B6", "#03353E") },
+                { LogLevel.Evolve, new Tuple<string, string, string>("Cyan", "#B4E1FD", "#EC008C") },
+                { LogLevel.Berry, new Tuple<string, string, string>("Orange", "#FF8308", "#FF6600") },
+                { LogLevel.Egg, new Tuple<string, string, string>("Cyan", "#B4E1FD", "#EC008C") },
+                { LogLevel.Debug, new Tuple<string, string, string>("Grey", "#B6B6B6", "#03353E") },
+                { LogLevel.Update, new Tuple<string, string, string>("Blue", "#0883FF", "#0883FF") },
+                { LogLevel.New, new Tuple<string, string, string>("Blue", "#0883FF", "#0883FF") },
+                { LogLevel.SoftBan, new Tuple<string, string, string>("Pink", "#FF1E8E", "#EC008C") },
+                { LogLevel.LevelUp, new Tuple<string, string, string>("Blue", "#0883FF", "#0883FF") },
+                { LogLevel.Gym, new Tuple<string, string, string>("Purple", "#8308FF", "#197B30") },
+                { LogLevel.Service , new Tuple<string, string, string>("Blue", "#0883FF", "#0883FF") }
         };
 
         private static SolidColorBrush DarkSolarizedBackground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#002B36"));
         private static SolidColorBrush LightSolarizedBackground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FDF6E3"));
-        private static SolidColorBrush SolarizedConsoleWhite = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#657b83"));
-        private static SolidColorBrush LightTabColor = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFE5E5E5"));
-        private static SolidColorBrush DarkTabColor = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#252525"));
+        private static SolidColorBrush SolarizedConsoleWhite = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#657B83"));
+        private static SolidColorBrush LightForeground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFF1F1F1"));
+        private static SolidColorBrush DarkForeground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#000000"));
 
         public MainClientWindow()
         {
@@ -85,8 +85,8 @@ namespace PoGo.Necrobot.Window
             DataContext = datacontext;
             txtCmdInput.Text = TinyIoCContainer.Current.Resolve<UITranslation>().InputCommand;
 
-            Application.Current.MainWindow.Width = Settings.Default.Width;
-            Application.Current.MainWindow.Height = Settings.Default.Height;
+            Width = Settings.Default.Width;
+            Height = Settings.Default.Height;
 
             BrowserSync();
             ConsoleSync();
@@ -138,8 +138,6 @@ namespace PoGo.Necrobot.Window
             Theme.ItemsSource = new List<string> { "Red", "Green", "Blue", "Purple", "Orange", "Lime", "Emerald", "Teal", "Cyan", "Cobalt", "Indigo", "Violet", "Pink", "Magenta", "Crimson", "Amber", "Yellow", "Brown", "Olive", "Steel", "Mauve", "Taupe", "Sienna" };
             MapMode.ItemsSource = new List<string> { "Normal", "Satellite" };
             ConsoleThemer.ItemsSource = new List<string> { "Default", "Low Contrast (Light)", "Low Contrast (Dark)" };
-            var LightTabColor = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFE5E5E5"));
-            var DarkTabColor = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#252525"));
 
             //=============STARTUP CONFIGURATION=============\\
             if (Settings.Default.ConsoleTheme == "" || Settings.Default.Theme == "" || Settings.Default.Scheme == "" || Settings.Default.SchemeValue == "")
@@ -163,12 +161,24 @@ namespace PoGo.Necrobot.Window
 
         private void TimerTick(object sender, ElapsedEventArgs e)
         {
-            var Theme = Settings.Default.Theme;
-            var Scheme = Settings.Default.Scheme;
+            var ThemeValue = Settings.Default.Theme;
+            var SchemeValue = Settings.Default.Scheme;
             Application.Current.Dispatcher.Invoke(delegate
             {
-                if (Theme != Settings.Default.Theme | Scheme != Settings.Default.Scheme & Settings.Default.ResetLayout == true)
+                if (ThemeValue != Settings.Default.Theme | SchemeValue != Settings.Default.Scheme & Settings.Default.ResetLayout == true)
                     Settings.Default.ResetLayout = false;
+                if (ThemeValue == "Yellow")
+                {
+                    Theme.Foreground = DarkForeground;
+                    Scheme.Foreground = DarkForeground;
+                    MapMode.Foreground = DarkForeground;
+                }
+                else
+                {
+                    Theme.Foreground = LightForeground;
+                    Scheme.Foreground = LightForeground;
+                    MapMode.Foreground = LightForeground;
+                }
                 Settings.Default.Save();
             });
         }
@@ -240,21 +250,26 @@ namespace PoGo.Necrobot.Window
         private DateTime lastClearLog = DateTime.Now;
         public void LogToConsoleTab(string message, LogLevel level, string color)
         {
-            if (Settings.Default.ConsoleTheme == "Low Contrast (Light)")
-                color = ConsoleColors[level].Item3;
-            if (Settings.Default.ConsoleTheme == "Low Contrast (Dark)")
-                color = ConsoleColors[level].Item2;
-            else if (Settings.Default.ConsoleTheme == "Default" || Settings.Default.ResetLayout == true)
-                color = ConsoleColors[level].Item1;
-
             consoleLog.Dispatcher.BeginInvoke(new Action(() =>
             {
+                if (Settings.Default.ConsoleTheme == "Low Contrast (Light)")
+                    color = ConsoleColors[level].Item3;
+                if (Settings.Default.ConsoleTheme == "Low Contrast (Dark)")
+                    color = ConsoleColors[level].Item2;
+                else if (Settings.Default.ConsoleTheme == "Default" || Settings.Default.ResetLayout == true)
+                    color = ConsoleColors[level].Item1;
+
+                if (string.IsNullOrEmpty(color))
+                {
+                    NecroBot.Logic.Logging.Logger.Write($"No Color Detected for LogLevel ({level}) on this Scheme...", LogLevel.Error);
+                    return;
+                }
+
                 if (lastClearLog.AddMinutes(15) < DateTime.Now)
                 {
                     consoleLog.Document.Blocks.Clear();
                     lastClearLog = DateTime.Now;
                 }
-                if (string.IsNullOrEmpty(color) || color == "Black") color = "white";
 
                 consoleLog.AppendText(message + "\r", color);
                 consoleLog.ScrollToEnd();
@@ -468,6 +483,11 @@ namespace PoGo.Necrobot.Window
                 ConsoleThemer.Background = DarkSolarizedBackground;
                 ConsoleThemer.Foreground = SolarizedConsoleWhite;
             }
+            // Reset the Console Blocks to prevent any mixups
+            consoleLog.Document.Blocks.Clear();
+            lastClearLog = DateTime.Now;
+            // Add Log to Say Scheme has Changed
+            NecroBot.Logic.Logging.Logger.Write($"Console Layout is now '{Settings.Default.ConsoleTheme}'", LogLevel.Update);
             Settings.Default.Save();
             ResetSync();
         }
@@ -478,29 +498,11 @@ namespace PoGo.Necrobot.Window
             {
                 Settings.Default.Scheme = "Light";
                 Settings.Default.SchemeValue = "BaseLight";
-
-                tabAccounts.Background = LightTabColor;
-                tabBrowser.Background = LightTabColor;
-                tabMap.Background = LightTabColor;
-                tabSniper.Background = LightTabColor;
-                tabConsole.Background = LightTabColor;
-                tabPokemons.Background = LightTabColor;
-                tabItems.Background = LightTabColor;
-                tabEggs.Background = LightTabColor;
             }
             else if (Scheme == "Dark")
             {
                 Settings.Default.Scheme = "Dark";
                 Settings.Default.SchemeValue = "BaseDark";
-
-                tabAccounts.Background = DarkTabColor;
-                tabBrowser.Background = DarkTabColor;
-                tabMap.Background = DarkTabColor;
-                tabSniper.Background = DarkTabColor;
-                tabConsole.Background = DarkTabColor;
-                tabPokemons.Background = DarkTabColor;
-                tabItems.Background = DarkTabColor;
-                tabEggs.Background = DarkTabColor;
             }
 
             ThemeManager.ChangeAppStyle(Application.Current, ThemeManager.GetAccent(Settings.Default.Theme), ThemeManager.GetAppTheme(Settings.Default.SchemeValue));
@@ -621,8 +623,8 @@ namespace PoGo.Necrobot.Window
 
         private void MetroWindow_Closing(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            Application.Current.MainWindow.Height = Settings.Default.Height;
-            Application.Current.MainWindow.Width = Settings.Default.Width;
+            Settings.Default.Height = Height;
+            Settings.Default.Width = Width;
             Settings.Default.Save();
             Process.GetCurrentProcess().Kill();
         }

--- a/PoGo.Necrobot.Window/PoGo.Necrobot.Window.csproj
+++ b/PoGo.Necrobot.Window/PoGo.Necrobot.Window.csproj
@@ -635,24 +635,60 @@
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
     <AppDesigner Include="Properties\" />
-    <Resource Include="Resources\Fonts\Lato\Lato-Black.ttf" />
-    <Resource Include="Resources\Fonts\Lato\Lato-BlackItalic.ttf" />
-    <Resource Include="Resources\Fonts\Lato\Lato-Bold.ttf" />
-    <Resource Include="Resources\Fonts\Lato\Lato-BoldItalic.ttf" />
-    <Resource Include="Resources\Fonts\Lato\Lato-Hairline.ttf" />
-    <Resource Include="Resources\Fonts\Lato\Lato-HairlineItalic.ttf" />
-    <Resource Include="Resources\Fonts\Lato\Lato-Heavy.ttf" />
-    <Resource Include="Resources\Fonts\Lato\Lato-HeavyItalic.ttf" />
-    <Resource Include="Resources\Fonts\Lato\Lato-Italic.ttf" />
-    <Resource Include="Resources\Fonts\Lato\Lato-Light.ttf" />
-    <Resource Include="Resources\Fonts\Lato\Lato-LightItalic.ttf" />
-    <Resource Include="Resources\Fonts\Lato\Lato-Medium.ttf" />
-    <Resource Include="Resources\Fonts\Lato\Lato-MediumItalic.ttf" />
-    <Resource Include="Resources\Fonts\Lato\Lato-Regular.ttf" />
-    <Resource Include="Resources\Fonts\Lato\Lato-Semibold.ttf" />
-    <Resource Include="Resources\Fonts\Lato\Lato-SemiboldItalic.ttf" />
-    <Resource Include="Resources\Fonts\Lato\Lato-Thin.ttf" />
-    <Resource Include="Resources\Fonts\Lato\Lato-ThinItalic.ttf" />
+    <Resource Include="Resources\Fonts\Lato\Lato-Black.ttf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="Resources\Fonts\Lato\Lato-BlackItalic.ttf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="Resources\Fonts\Lato\Lato-Bold.ttf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="Resources\Fonts\Lato\Lato-BoldItalic.ttf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="Resources\Fonts\Lato\Lato-Hairline.ttf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="Resources\Fonts\Lato\Lato-HairlineItalic.ttf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="Resources\Fonts\Lato\Lato-Heavy.ttf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="Resources\Fonts\Lato\Lato-HeavyItalic.ttf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="Resources\Fonts\Lato\Lato-Italic.ttf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="Resources\Fonts\Lato\Lato-Light.ttf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="Resources\Fonts\Lato\Lato-LightItalic.ttf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="Resources\Fonts\Lato\Lato-Medium.ttf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="Resources\Fonts\Lato\Lato-MediumItalic.ttf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="Resources\Fonts\Lato\Lato-Regular.ttf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="Resources\Fonts\Lato\Lato-Semibold.ttf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="Resources\Fonts\Lato\Lato-SemiboldItalic.ttf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="Resources\Fonts\Lato\Lato-Thin.ttf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="Resources\Fonts\Lato\Lato-ThinItalic.ttf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Resource>
     <Resource Include="Resources\Entypo.ttf" />
   </ItemGroup>
   <ItemGroup>
@@ -911,7 +947,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\packages\Selenium.WebDriver.ChromeDriver.2.29.0\build\Selenium.WebDriver.ChromeDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Selenium.WebDriver.ChromeDriver.2.29.0\build\Selenium.WebDriver.ChromeDriver.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)\packages\Fody.2.0.8\build\netstandard1.4\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Fody.2.0.8\build\netstandard1.4\Fody.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\Fody.2.0.9\build\netstandard1.4\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Fody.2.0.9\build\netstandard1.4\Fody.targets'))" />
   </Target>
   <UsingTask TaskName="CosturaCleanup" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll" TaskFactory="CodeTaskFactory">
     <ParameterGroup>
@@ -959,7 +995,7 @@ del /s /q x64
 rmdir /s /q x64</PostBuildEvent>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\packages\Selenium.WebDriver.ChromeDriver.2.29.0\build\Selenium.WebDriver.ChromeDriver.targets" Condition="Exists('$(SolutionDir)\packages\Selenium.WebDriver.ChromeDriver.2.29.0\build\Selenium.WebDriver.ChromeDriver.targets')" />
-  <Import Project="$(SolutionDir)\packages\Fody.2.0.8\build\netstandard1.4\Fody.targets" Condition="Exists('$(SolutionDir)\packages\Fody.2.0.8\build\netstandard1.4\Fody.targets')" />
+  <Import Project="$(SolutionDir)\packages\Fody.2.0.9\build\netstandard1.4\Fody.targets" Condition="Exists('$(SolutionDir)\packages\Fody.2.0.9\build\netstandard1.4\Fody.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/PoGo.Necrobot.Window/packages.config
+++ b/PoGo.Necrobot.Window/packages.config
@@ -3,7 +3,7 @@
   <package id="Costura.Fody" version="1.4.1" targetFramework="net462" developmentDependency="true" />
   <package id="DotNetBrowser" version="1.10" targetFramework="net462" />
   <package id="Extended.Wpf.Toolkit" version="3.0" targetFramework="net462" />
-  <package id="Fody" version="2.0.8" targetFramework="net462" developmentDependency="true" />
+  <package id="Fody" version="2.0.9" targetFramework="net462" developmentDependency="true" />
   <package id="Geocoding.net" version="3.6.0" targetFramework="net462" />
   <package id="GMap.NET.Presentation" version="1.7.5" targetFramework="net462" />
   <package id="Google.Protobuf" version="3.3.0" targetFramework="net462" />

--- a/RocketBot2/RocketBot2.csproj
+++ b/RocketBot2/RocketBot2.csproj
@@ -1078,7 +1078,7 @@ foreach (var item in filesToCleanup)
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\packages\Selenium.WebDriver.ChromeDriver.2.29.0\build\Selenium.WebDriver.ChromeDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Selenium.WebDriver.ChromeDriver.2.29.0\build\Selenium.WebDriver.ChromeDriver.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)\packages\Fody.2.0.8\build\netstandard1.4\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Fody.2.0.8\build\netstandard1.4\Fody.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\Fody.2.0.9\build\netstandard1.4\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Fody.2.0.9\build\netstandard1.4\Fody.targets'))" />
   </Target>
   <PropertyGroup>
     <PostBuildEvent>cd "$(TargetDir)"
@@ -1089,7 +1089,7 @@ del /s /q x64
 rmdir /s /q x64</PostBuildEvent>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\packages\Selenium.WebDriver.ChromeDriver.2.29.0\build\Selenium.WebDriver.ChromeDriver.targets" Condition="Exists('$(SolutionDir)\packages\Selenium.WebDriver.ChromeDriver.2.29.0\build\Selenium.WebDriver.ChromeDriver.targets')" />
-  <Import Project="$(SolutionDir)\packages\Fody.2.0.8\build\netstandard1.4\Fody.targets" Condition="Exists('$(SolutionDir)\packages\Fody.2.0.8\build\netstandard1.4\Fody.targets')" />
+  <Import Project="$(SolutionDir)\packages\Fody.2.0.9\build\netstandard1.4\Fody.targets" Condition="Exists('$(SolutionDir)\packages\Fody.2.0.9\build\netstandard1.4\Fody.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/RocketBot2/packages.config
+++ b/RocketBot2/packages.config
@@ -3,7 +3,7 @@
   <package id="AeroWizard" version="2.1.10" targetFramework="net462" />
   <package id="CommandLineParser" version="1.9.71" targetFramework="net462" />
   <package id="Costura.Fody" version="1.4.1" targetFramework="net462" developmentDependency="true" />
-  <package id="Fody" version="2.0.8" targetFramework="net462" developmentDependency="true" />
+  <package id="Fody" version="2.0.9" targetFramework="net462" developmentDependency="true" />
   <package id="GeoCoordinate.NetStandard1" version="1.0.1" targetFramework="net462" />
   <package id="GMap.NET.WindowsForms" version="1.7.5" targetFramework="net462" />
   <package id="Google.Protobuf" version="3.3.0" targetFramework="net462" />


### PR DESCRIPTION
## Fixes:
- Fix for Console Colors Calling Incorrectly
- Fix for Console Missing Light-Scheme Colors
- Fix for Console Starting, Regardless of User Settings
- Fixes for Incorrect Font Calling
- Theme, Scheme, and Map Mode Foregrounds now have their Correct Settings
- App Now Saves and Loads Width and Height of Application Correctly
- Tab Backgrounds are now Their Correct Color (Transparent, for now)
- Fixes Circumstance in which if you cancel Bulk Transfer, The Pokemon would still be 'Transferring...'
- Fix Typos, Whitespace, and Unnecessary 'RenderTransformOrigin' XAML and Adds some Extra Simplifications

## Improvements:
- Removes Both Error and AccountSwitch Popups in exchange to display on lblAccount
- Updated Fody to 2.0.9 from 2.0.8
- Errors that require Exiting will both display on lblAccount, Will Auto Shutdown after 10 Seconds, and Will Log the Error in Console
- Removing Popups has Allowed the App to take full screen on it's window (In Source)
- Minimum Height Added, to Prevent too Small of a Size Decrease
- Logging In Start Message Tweaked!
- Adds WIP Evolve All and Favorite All Button with WIP Functions (Buttons disabled until completed)
- Player Info Buddy Initial Picture has been Corrected...

Signed-off-by: CDAGaming <cstack2011@yahoo.com>