### PR TITLE
Reapply Level Up Reward Fix

### DIFF
--- a/PoGo.NecroBot.Logic/Utils/Statistics.cs
+++ b/PoGo.NecroBot.Logic/Utils/Statistics.cs
@@ -150,7 +150,7 @@ namespace PoGo.NecroBot.Logic.Utils
                     }
                     else
                     {
-                        LevelUpRewardsResponse Result = await GetLevelUpRewards(session).ConfigureAwait(false);
+                        LevelUpRewardsResponse Result = await inventory.GetLevelUpRewards(stat.Level).ConfigureAwait(false);
 
                         if (Result.ToString().ToLower().Contains("awarded_already"))
                             LevelForRewards = stat.Level + 1;
@@ -158,6 +158,7 @@ namespace PoGo.NecroBot.Logic.Utils
                         if (Result.ToString().ToLower().Contains("success"))
                         {
                             Logger.Write("Leveled up: " + stat.Level, LogLevel.Info);
+                            LevelForRewards = stat.Level + 1;
 
                             RepeatedField<ItemAward> items = Result.ItemsAwarded;
 
@@ -197,11 +198,6 @@ namespace PoGo.NecroBot.Logic.Utils
             TotalPokemonTransferred = 0;
             _initSessionDateTime = DateTime.Now;
             _exportStats = new StatsExport();
-        }
-
-        public async Task<LevelUpRewardsResponse> GetLevelUpRewards(ISession ctx)
-        {
-            return await ctx.Inventory.GetLevelUpRewards(LevelForRewards).ConfigureAwait(false);
         }
 
         public double GetRuntime()


### PR DESCRIPTION
## Short Description:
Reapplies PR #1746 due to the changes in `PoGo.NecroBot.Logic/Utils/Statistics.cs` being overwritten by https://github.com/Necrobot-Private/NecroBot/commit/29c82279f5ded634b5e135383c2e7417ed7932d3#diff-5b443eea65f8ae318580c32ef320f856

## Fixes (provide links to github issues if you can):
#1807
